### PR TITLE
Use dependabot auto merge 

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -21,6 +21,7 @@ jobs:
         uses: fastify/github-action-merge-dependabot@v3.5.3
         with:
           github-token: ${{ secrets.GH_TOKEN }}
+          use-github-auto-merge: true
         env:
             GITHUB_TOKEN: ${{ secrets.GH_TOKEN || secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION

auto merge broke due to the github token expiring which will happen a lot so let's see if this new feature github automerge 
will fix it.

probably can deprecate using this github action eventually.

https://github.com/fastify/github-action-merge-dependabot/pull/302#issue-1432984745

Signed-off-by: jcowhigjr <1895349+jcowhigjr@users.noreply.github.com>