### PR TITLE
Fix Gemfile.next.lock getting behind dependabot updates

### DIFF
--- a/Gemfile.next.lock
+++ b/Gemfile.next.lock
@@ -130,9 +130,8 @@ GEM
     debug_inspector (1.1.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
-    dotenv (3.0.2)
-    drb (2.2.0)
-      ruby2_keywords
+    dotenv (3.1.0)
+    drb (2.2.1)
     easy_translate (0.5.1)
       thread
       thread_safe
@@ -228,7 +227,7 @@ GEM
     json (2.7.1)
     jwt (2.5.0)
     language_server-protocol (3.17.0.3)
-    lefthook (1.6.1)
+    lefthook (1.6.4)
     listen (3.8.0)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
@@ -246,7 +245,7 @@ GEM
       net-imap
       net-pop
       net-smtp
-    marcel (1.0.2)
+    marcel (1.0.4)
     matrix (0.4.2)
     method_source (1.0.0)
     mime-types (3.4.1)
@@ -315,6 +314,7 @@ GEM
       syntax_tree-haml (>= 1.1.0)
       syntax_tree-rbs (>= 0.2.0)
     prettier_print (1.1.0)
+    prism (0.24.0)
     propshaft (0.8.0)
       actionpack (>= 7.0.0)
       activesupport (>= 7.0.0)
@@ -398,7 +398,7 @@ GEM
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
     rexml (3.2.6)
-    rubocop (1.60.2)
+    rubocop (1.61.0)
       json (~> 2.3)
       language_server-protocol (>= 3.17.0)
       parallel (~> 1.10)
@@ -409,8 +409,9 @@ GEM
       rubocop-ast (>= 1.30.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 3.0)
-    rubocop-ast (1.30.0)
-      parser (>= 3.2.1.0)
+    rubocop-ast (1.31.0)
+      parser (>= 3.3.0.4)
+      prism (>= 0.24.0)
     rubocop-minitest (0.34.5)
       rubocop (>= 1.39, < 2.0)
       rubocop-ast (>= 1.30.0, < 2.0)

--- a/bin/setup-next
+++ b/bin/setup-next
@@ -18,7 +18,19 @@ FileUtils.chdir APP_ROOT do
 
   puts "== Installing dependencies =="
   system! "gem install bundler --conservative"
-  system("next bundle check") || system!("next bundle install")
+
+  puts "\n== start with a gem versions at current Gemfile.lock =="
+
+  if File.exist?("Gemfile.next.lock")
+    FileUtils.rm "Gemfile.next.lock"
+  end
+
+  if File.exist?("Gemfile.lock")
+    FileUtils.cp "Gemfile.lock", "Gemfile.next.lock"
+  end
+
+  puts "\n== Installing next gems =="
+  system!("next bundle install")
 
   # puts "\n== Copying sample files =="
   # unless File.exist?("config/database.yml")

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,12 @@
 # https://github.com/evilmartians/lefthook/blob/master/docs/full_guide.md
 #
 pre-push:
+  pre-command: git stash
   commands:
+    test-next:
+      tags: backend
+      run: RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` bin/setup-next &&
+           RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` HEADLESS=true CUPRITE=true APP_HOST='127.0.0.1' next rails test:all
     packages-audit:
       tags: frontend security
       run: yarn audit

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -8,7 +8,7 @@ pre-push:
     test-next:
       tags: backend
       run: RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` bin/setup-next &&
-           RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` HEADLESS=true CUPRITE=true APP_HOST='127.0.0.1' next rails test:all
+           RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` HEADLESS=true CUPRITE=true APP_HOST='127.0.0.1' next rails test
     packages-audit:
       tags: frontend security
       run: yarn audit
@@ -55,7 +55,7 @@ pre-commit:
       tags: backend tests
       run: RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` bin/setup &&
            RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` bin/rails test:prepare --trace &&
-           RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` CUPRITE=true bin/rails test:all
+           RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` CUPRITE=true bin/rails test
 fixer:
   parallel: true
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -33,7 +33,7 @@ pre-push:
       tags: backend tests
       run: RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` bin/setup &&
            RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` bin/rails test:prepare --trace &&
-           RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` CUPRITE=true bin/rails test:all
+           RAILS_ENV=test RAILS_MASTER_KEY=`cat config/credentials/test.key` CUPRITE=true bin/rails test:system
 
 pre-commit:
   parallel: true


### PR DESCRIPTION
This pull request fixes the problem of the Gemfile.next.lock getting behind dependabot updates.
 It also includes changes to run the same test locally as GitHub Actions runs for the Gemfile next.

Additionally it optimizes time spent testing somewhat.

 Additionally, it experiments with stashing before running pre-push commands for safety.
 It modifies the pre-push commands to run unit tests only on a commit
and to run system tests only before a push.

