### PR TITLE
Potential fix for code scanning alert no. 9: Incomplete URL substring sanitization

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -20,7 +20,8 @@ Capybara.register_driver :ferrum_block_fonts do |app|
   browser = Ferrum::Browser.new
 
   browser.on(:request) do |request|
-    if request.url.include?('fonts.gstatic.com')
+    host = URI(request.url).host
+    if host == 'fonts.gstatic.com'
       request.abort
     end
   end


### PR DESCRIPTION
Potential fix for [https://github.com/jcowhigjr/yelp_search_demo/security/code-scanning/9](https://github.com/jcowhigjr/yelp_search_demo/security/code-scanning/9)

To fix the problem, we need to parse the URL and check the host value instead of using a substring check. This ensures that the check is accurate and not bypassed by embedding the allowed host in different parts of the URL.

- Parse the URL using the `URI` module to extract the host.
- Check if the host matches the allowed host 'fonts.gstatic.com'.
- Update the relevant lines in the file `test/test_helper.rb`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
