### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete URL substring sanitization

### DIFF
--- a/test/system/system_helper.rb
+++ b/test/system/system_helper.rb
@@ -2,12 +2,14 @@
 # require "rails_helper.rb"
 
 require 'capybara/ferrum'
+require 'uri'
 
 Capybara.register_driver :ferrum_block_fonts do |app|
   browser = Ferrum::Browser.new
 
   browser.on(:request) do |request|
-    if request.url.include?('fonts.gstatic.com')
+    host = URI(request.url).host
+    if host == 'fonts.gstatic.com'
       request.abort
     end
   end


### PR DESCRIPTION
Potential fix for [https://github.com/jcowhigjr/yelp_search_demo/security/code-scanning/8](https://github.com/jcowhigjr/yelp_search_demo/security/code-scanning/8)

To fix the problem, we need to parse the URL and check the host value instead of using a substring check. This ensures that the check handles arbitrary subdomain sequences correctly and prevents bypassing the security check by embedding the allowed host in an unexpected location.

The best way to fix the problem without changing existing functionality is to use the `URI` module to parse the URL and then check if the host matches 'fonts.gstatic.com'. This change should be made in the file `test/system/system_helper.rb` on line 10.

We need to import the `URI` module to implement the changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
