### PR TITLE
docs: Update RAILS_TEST_KEY secret config in DevNotes

### DIFF
--- a/DevNotes.md
+++ b/DevNotes.md
@@ -319,17 +319,33 @@ Dependabot alerts are resulting in very frequent security updates..
     (2) Now let dependabot handle it automatically as well.
 
 Dependabot opens its own PRs and auto-approves them, tests them and merges them if they succeed therefore it needs its own (yet the same) secrets similar to the action workflows (see .github/.. files) I think githubs secret management feels off combined with Rails environments and Heroku environmennts it seems like a mismatch feeling around for the correct pattern.
--- the tests CI requires Dendabot/RAILS_MASTER_KEY
+-- the tests CI requires RAILS_TEST_KEY
 -- the heroku feature branch deploy requires HEROKU_API_KEY from the Actions/Environment
 -- the main.ci develop deploy requires the repository secret Actions/RepositorySecrets HEROKU_APP_NAME and the above API KEY
 
-Dependabot and Regular PRs run either in Actions/Dependabot Envs so the rails credentials setup requires updating the secret in two places in github see main gith hub workflow for RAILS_TEST_SECRET usage.
+Dependabot and Regular PRs run either in Actions/Dependabot Envs so the rails credentials setup requires updating the secret in two places in github see main gith hub workflow for RAILS_TEST_KEY usage.
 
 Heroku recommended <https://guides.rubyonrails.org/security.html> changing the rails master credentials because the master key is stored in and environment variable they had saved them in plain text in a compromised database.
 
 <https://blog.saeloun.com/2019/10/10/rails-6-adds-support-for-multi-environment-credentials.html>
 heroku config:set RAILS_MASTER_KEY=rails-production-key
 EDITOR="code --wait" bin/rails credentials:edit -e production MASTER_KEY=your-master-key
+
+## Configuring RAILS_TEST_KEY
+
+Both regular PRs and Dependabot PRs need access to the `RAILS_TEST_KEY` secret to decrypt test credentials. You must configure this secret in two different locations in GitHub:
+
+### Repository Secrets
+
+- Navigate to **Settings > Secrets and variables > Actions** in your repository.
+- Click **New repository secret**, set the name to `RAILS_TEST_KEY`, and paste in the contents of `config/credentials/test.key`.
+
+### Dependabot Secrets
+
+- In **Settings > Secrets and variables**, select the **Dependabot** tab.
+- Add a new secret named `RAILS_TEST_KEY` with the same key contents.
+
+Note that both stores must be updated so that regular PRs and Dependabot PRs can decrypt test credentials.
 
 for github actions:
 add a branch or repository level secret called RAILS_TEST_KEY with the value of your config/credentials/test.key (see main.yml)


### PR DESCRIPTION
This PR fixes incorrect secret names and adds clear setup instructions for both Repository and Dependabot secrets.

## Changes Made

- Fixed "Dendabot/RAILS_MASTER_KEY" to "RAILS_TEST_KEY" on line 322
- Fixed "RAILS_TEST_SECRET" to "RAILS_TEST_KEY" on line 326
- Added comprehensive **Configuring RAILS_TEST_KEY** section with:
  - **Repository Secrets** subsection with step-by-step GitHub UI instructions
  - **Dependabot Secrets** subsection with clear setup steps
  - Important note about requiring both secret stores for CI/CD to work properly

## Why This Matters

Both regular PRs and Dependabot PRs need access to the same `RAILS_TEST_KEY` secret to decrypt test credentials. The previous documentation had inconsistent naming and lacked clear setup instructions, which could lead to CI failures.

Now developers have clear, actionable steps to configure GitHub secrets correctly for both workflows.