### PR TITLE
Fix Tailwind CSS race condition in CI tests

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -45,7 +45,7 @@ alias = ["l"]
 
 [tasks.test-prepare]
 description = "Prepare test database for main tests"
-run = "bin/rails test:prepare --trace"
+run = "bin/rails tailwindcss:build && bin/rails test:prepare --trace"
 
 [tasks.test]
 description = "Run unit and integration tests for main application"
@@ -59,7 +59,7 @@ depends = ["test-prepare"]
 
 [tasks.test-next-prepare]
 description = "Prepare test database for 'next' environment"
-run = "next rails test:prepare --trace"
+run = "next rails tailwindcss:build && next rails test:prepare --trace"
 
 [tasks.test-next-run]
 description = "Run unit and integration tests for 'next' environment"


### PR DESCRIPTION
## Problem

Fixes #838 - Intermittent CI failure where tests can't find `/app/assets/builds/tailwind.css` due to a race condition between asset building and test execution.

## Root Cause

The `test-prepare` and `test-next-prepare` tasks in `mise.toml` only ran database preparation but didn't ensure Tailwind CSS was built first. This caused a race condition where:
- Tests would sometimes start before Tailwind CSS was compiled.
- The required `tailwind.css` file wouldn't exist when ERB templates tried to reference it.
- CI would fail intermittently with `No such file or directory @ rb_sysopen` error.

## Solution

Modified both tasks to build Tailwind CSS before test preparation:
- `test-prepare`: Now runs `bin/rails tailwindcss:build && bin/rails test:prepare --trace`.
- `test-next-prepare`: Now runs `next rails tailwindcss:build && next rails test:prepare --trace`.

This ensures Tailwind CSS is always compiled before any tests run in both environments.

## Changes

- Updated `mise.toml` to include `tailwindcss:build` in both test preparation tasks.
- Removed incorrect `build-tailwind` command from pre-push hook.

## Testing

- Verified `mise run test-prepare` builds CSS before database setup.
- Confirmed `tailwind.css` file is created before tests run.
- All local pre-push hooks pass including system tests.

## Impact

This fix eliminates the race condition by ensuring deterministic execution order: CSS build → database setup → tests. The intermittent CI failures should now be resolved.