### PR TITLE
Rails 8.1 Upgrade – PR2: add defaults initializer (no behavior flips)

### DIFF
--- a/config/initializers/new_framework_defaults_8_1.rb
+++ b/config/initializers/new_framework_defaults_8_1.rb
@@ -1,0 +1,14 @@
+# Rails 8.1 defaults initializer
+#
+# This file is intentionally conservative: it does not flip any defaults yet.
+# We will enable individual defaults in small PRs after verification.
+#
+# To enable a default, uncomment it in a future PR and run the full test suite.
+# Keep each change minimal and revert-friendly.
+#
+# Example (names will be adjusted to the exact 8.1 options in follow-up PRs):
+# Rails.application.config.active_support.cache_format_version = 7.1
+# Rails.application.config.action_controller.raise_on_missing_callback_actions = true
+# Rails.application.config.active_record.default_legacy_connection_handling = false
+
+# End of file


### PR DESCRIPTION
Summary
- Add config/initializers/new_framework_defaults_8_1.rb as a conservative scaffold (no defaults enabled yet).
- Follow-ups will enable specific defaults in small PRs with tests.

Changes
- [x] New initializer: new_framework_defaults_8_1.rb (comment-only; safe)

Verification
- mise exec -- bin/rails zeitwerk:check
- mise exec -- bin/rails db:prepare
- mise exec -- bin/rails test
- mise exec -- bin/rails test:system

Risk/rollback
- None; file is comment-only and does not change behavior.

Issue linkage
- Relates to #873
