### PR TITLE
Rails 8.1: per-file initializer for action_view.render_tracker

### DIFF
--- a/config/initializers/rails_8_1/01_action_view_render_tracker.rb
+++ b/config/initializers/rails_8_1/01_action_view_render_tracker.rb
@@ -1,0 +1,3 @@
+# Rails 8.1: Use a Ruby parser to track dependencies between Action View templates.
+# Safe change; does not alter user-facing behavior.
+Rails.configuration.action_view.render_tracker = :ruby


### PR DESCRIPTION
Move render_tracker into a dedicated initializer to avoid conflicts. No behavior change; improves template dependency tracking. Enable auto-merge when checks pass.