### PR TITLE
🚀 Fix: Restore Dependabot Auto-Merge by Removing workflow_run Trigger

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,10 +14,9 @@ on:
     branches:
       - develop
       - main
-  workflow_run:
-    workflows: ["Dependabot Risk Assessment"]
-    types:
-      - completed
+    types: [opened, synchronize, reopened]
+  # Removed workflow_run trigger that was preventing CI from running
+  # on updated Dependabot PR commits. Risk assessment logic moved inline.
 
 # Add workflow-level permissions to fix permission issues
 permissions:
@@ -65,7 +64,7 @@ jobs:
   test-next:
     runs-on: ubuntu-latest
     needs: [get-risk-assessment]
-    if: always() && !cancelled()
+    if: always() && !cancelled() && (needs.get-risk-assessment.result == 'success' || needs.get-risk-assessment.result == 'skipped')
     permissions:
       contents: read # Added for least privilege
     steps:
@@ -114,7 +113,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     needs: [get-risk-assessment]
-    if: always() && !cancelled()
+    if: always() && !cancelled() && (needs.get-risk-assessment.result == 'success' || needs.get-risk-assessment.result == 'skipped')
     permissions:
       contents: read # Added for least privilege
     steps:


### PR DESCRIPTION
## Overview
This PR fixes the critical bug where **5 Dependabot PRs remain indefinitely blocked** despite having auto-merge enabled. The root cause was a  trigger preventing CI from running on updated PR commits.

## Problem
- **Auto-merge enabled but blocked**: All 5 Dependabot PRs (#885-#889) show auto-merge enabled but 
- **Zero status checks**: PRs show  - no CI runs for current commit SHAs  
- **Workflow dependency race condition**:  trigger created circular dependency between main CI and Risk Assessment workflows
- **Manual intervention required**: Every dependency update needed manual merging, defeating automation

## Root Cause
Introduced in **commit 50649c4 (July 5th, 2025)**, the problematic configuration:

```yaml
# .github/workflows/main.yml (BEFORE)
workflow_run:
  workflows: ["Dependabot Risk Assessment"]  # ⚠️ This blocked CI on PR updates
  types: [completed]
```

**Failure sequence:**
1. Dependabot creates PR → Both workflows trigger ✅  
2. Risk Assessment completes → Main CI runs for initial commit ❌ (often fails)
3. Dependabot updates PR → **NEW COMMITS DON'T TRIGGER CI** ⛔
4. Auto-merge blocked indefinitely by missing status checks

## Solution
### Changes Made:
- **Remove  trigger** that was blocking CI on PR updates
- **Add explicit  types**:  
- **Keep risk assessment logic inline** for Dependabot-specific optimizations
- **Fix job dependencies** to handle optional risk assessment results

### After Fix:
```yaml  
# .github/workflows/main.yml (AFTER)
pull_request:
  branches: [develop, main]
  types: [opened, synchronize, reopened]  # ✅ Triggers on ALL PR updates
# Removed workflow_run dependency
```

## Impact
- ✅ **Restores auto-merge functionality**: CI will run on all Dependabot PR updates
- ✅ **Zero manual intervention**: Dependency updates merge automatically when tests pass
- ✅ **Maintains intelligent features**: Risk assessment still optimizes test execution  
- ✅ **Fixes 5 blocked PRs**: #885, #886, #887, #888, #889 will have CI triggered

## Testing Strategy
1. **This PR itself tests the fix**: CI should run properly on this feature branch
2. **Monitor existing Dependabot PRs**: They should get fresh CI runs after this merges
3. **Verify auto-merge completion**: Previously blocked PRs should merge automatically

## Verification Commands
```bash
# Check CI triggers on Dependabot PRs
gh run list --workflow="Ruby on Rails CI" --limit=10

# Confirm auto-merge status  
gh pr list --author app/dependabot --json number,title,statusCheckRollup,autoMerge
```

Fixes #891 
Related PRs: #885, #886, #887, #888, #889

---
**Priority: Critical** - Restores automated dependency management workflow