### PR TITLE
Ensure review update failures render consistently

### DIFF
--- a/app/assets/builds/tailwind.css
+++ b/app/assets/builds/tailwind.css
@@ -1,0 +1,1 @@
+/* Stub stylesheet used for controller test rendering */

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -22,16 +22,27 @@ class ReviewsController < ApplicationController
   end
 
   def update
-    @review.update(review_params)
-    if @review.save
-      redirect_to @review.coffeeshop
-    else
-      format.turbo_stream do
-        render turbo_stream: turbo_stream.replace(:review, partial: 'reviews/form',
-                                                           locals: { review: @review })
+    @coffeeshop = @review.coffeeshop
+
+    respond_to do |format|
+      if @review.update(review_params)
+        format.html { redirect_to @coffeeshop }
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(@review,
+                                                    partial: 'reviews/show',
+                                                    locals: { review: @review })
+        end
+      else
+        flash.now[:review_error] = t('error.something_went_wrong')
+
+        format.html { render :edit, status: :unprocessable_entity }
+        format.turbo_stream do
+          render turbo_stream: turbo_stream.replace(@review,
+                                                    partial: 'reviews/edit_form',
+                                                    locals: { review: @review, coffeeshop: @coffeeshop }),
+                 status: :unprocessable_entity
+        end
       end
-      flash.now[:error] = t('error.something_went_wrong')
-      render @review.coffeeshop
     end
   end
 

--- a/app/views/reviews/_edit_form.html.erb
+++ b/app/views/reviews/_edit_form.html.erb
@@ -1,0 +1,26 @@
+<div class="container page-container z-depth-1">
+  <div class="row center">
+    <span class="page-text">Edit your review for <%= coffeeshop.name %></span>
+  </div>
+  <br><br>
+  <div class="row center">
+    <%= form_with(model: [review.user, review], method: :patch) do |f| %>
+      <%= f.hidden_field :user_id, value: current_user.id %>
+      <%= f.label :rating %>
+      <%= f.select(:rating,
+                   options_for_select([
+                                        ['★☆☆☆☆', 1],
+                                        ['★★☆☆☆', 2],
+                                        ['★★★☆☆', 3],
+                                        ['★★★★☆', 4],
+                                        ['★★★★★', 5],
+                                      ], review.rating),
+                   {},
+                   class: 'dark:bg-slate-900 dark:text-white') %>
+      <br><br>
+      <%= f.label(:content, t('reviews.form.please-give-a-b', name: coffeeshop.name)) %>
+      <%= f.text_area :content, class: 'materialize-textarea', required: true %>
+      <%= f.submit t('reviews.form.submit-review'), class: 'btn-large' %>
+    <% end %>
+  </div>
+</div>

--- a/app/views/reviews/edit.html.erb
+++ b/app/views/reviews/edit.html.erb
@@ -1,26 +1,3 @@
-
 <%= turbo_frame_tag @review do %>
-
-<%# <body class="landing-body"> %>
-    <div class="container page-container z-depth-1">
-    <div class="row center">
-         <span class="page-text">Edit your review for <%= @review.coffeeshop.name %></span>
-    </div>
-<br><br>
-<div class="row center">
-    <%= form_with(model: [@review.user, @review], method: 'patch') do |f| %>
-        <%= f.hidden_field :user_id, value: current_user.id %>
-        <%= f.label :rating %>
-        <%= f.select(:rating,
-                     options_for_select([['★☆☆☆☆', 1],['★★☆☆☆', 2], ['★★★☆☆', 3], ['★★★★☆', 4], ['★★★★★', 5]]),
-                     {}, { class: 'dark:bg-slate-900 dark:text-white' } ) %>
-        <br><br>
-        <%= f.label(:content, "Please give a brief description of your experience at #{@coffeeshop.name}.") %>
-        <%= f.text_area :content, class: 'materialize-textarea', required: true %>
-        <%= f.submit  'Submit Review', class: 'btn-large' %>
-    <% end %>
-</div>
-    </div>
-<%# </body> %>
-
+  <%= render 'edit_form', review: @review, coffeeshop: @coffeeshop %>
 <% end %>

--- a/test/controllers/reviews_controller_test.rb
+++ b/test/controllers/reviews_controller_test.rb
@@ -10,6 +10,12 @@ class ReviewsControllerTest < ActionDispatch::IntegrationTest
     @coffeeshop = coffeeshops(:one)
     @review = reviews(:one)
     @user = users(:one)
+    ActionController::Base.helpers.stubs(:asset_path).returns('/assets/tailwind.css')
+  end
+
+  def login_as(user)
+    ApplicationController.any_instance.stubs(:current_user).returns(user)
+    ApplicationController.any_instance.stubs(:logged_in?).returns(true)
   end
 
   test 'should create review' do
@@ -25,6 +31,55 @@ class ReviewsControllerTest < ActionDispatch::IntegrationTest
     end
 
     assert_redirected_to coffeeshop_path(@coffeeshop)
+  end
+
+  test 'updates review and redirects on html success' do
+    login_as(@user)
+
+    patch user_review_path(@user, @review, locale: nil),
+          params: {
+            review: {
+              content: 'Updated thoughts on espresso',
+              rating: 4,
+            },
+          }
+
+    assert_redirected_to coffeeshop_path(@review.coffeeshop)
+    assert_equal 'Updated thoughts on espresso', @review.reload.content
+  end
+
+  test 'renders edit with errors on html failure' do
+    login_as(@user)
+
+    patch user_review_path(@user, @review, locale: nil),
+          params: {
+            review: {
+              content: '',
+              rating: '',
+            },
+          }
+
+    assert_response :unprocessable_entity
+    assert_equal I18n.t('error.something_went_wrong'), flash[:review_error]
+    assert_includes @response.body, 'Edit your review for'
+  end
+
+  test 'returns turbo stream with form on failure for turbo clients' do
+    login_as(@user)
+
+    patch user_review_path(@user, @review, locale: nil),
+          params: {
+            review: {
+              content: '',
+              rating: '',
+            },
+          },
+          headers: { 'Accept' => 'text/vnd.turbo-stream.html' }
+
+    assert_response :unprocessable_entity
+    assert_equal 'text/vnd.turbo-stream.html', @response.media_type
+    assert_includes @response.body, '<turbo-stream action="replace"'
+    assert_includes @response.body, 'Edit your review for'
   end
 
   test 'should destroy the user review' do


### PR DESCRIPTION
## Summary
- add controller coverage for review update success and failure in both HTML and Turbo requests
- extract a reusable edit form partial and use it for Turbo failure rendering
- include a stub tailwind build asset so controller specs can render the layout during tests

## Testing
- bin/rails test test/controllers/reviews_controller_test.rb

------
https://chatgpt.com/codex/tasks/task_e_68e19fe698dc8321b73f0efd0a1a188d