### PR TITLE
ci: Add retry logic to system-test-next for consistency

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
           mise run test-next-run
       - name: system-test-next
         id: system-test-next
-        continue-on-error: false
+        continue-on-error: true # make the step always success and set status later
         # Skip system tests for low-risk Dependabot updates
         if: github.actor != 'dependabot[bot]' || (needs.get-risk-assessment.result != 'skipped' && needs.get-risk-assessment.outputs.skip-system-tests != 'true')
         env:
@@ -110,6 +110,29 @@ jobs:
           CI: true
         run: |
           mise run test-next-system
+      - name: system-test-next-retry
+        id: system-test-next-retry-1
+        continue-on-error: true # make the step always success and set status later
+        if: steps.system-test-next.outcome=='failure' && (github.actor != 'dependabot[bot]' || (needs.get-risk-assessment.result != 'skipped' && needs.get-risk-assessment.outputs.skip-system-tests != 'true'))
+        env:
+          RAILS_ENV: test
+          RAILS_MASTER_KEY: ${{ secrets.RAILS_TEST_KEY }}
+        run: |
+          mise run test-next-system -- --verbose
+      - name: Upload failed system test images (next)
+        uses: actions/upload-artifact@v4
+        if: steps.system-test-next.outcome=='failure'  ||  steps.system-test-next-retry-1.outcome=='failure' # check the step outcome, retry 1st time
+        with:
+          path: ./tmp/capybara/screenshots/failures_*.png
+      - name: set the status for next tests # set the workflow status if command failed
+        if: steps.system-test-next.outcome=='failure'
+        run: |
+          if ${{ steps.system-test-next-retry-1.outcome=='success' }}; then
+             echo 'the first next system test failed, but the second one passed'
+          else
+             echo 'the first next system test failed, and the second one also failed'
+             exit 1
+          fi
   test:
     runs-on: ubuntu-latest
     needs: [get-risk-assessment]


### PR DESCRIPTION
## Problem

The `test-next` and `test` jobs in CI had asymmetric behavior:
- `test` job: Retries system tests on failure with verbose output  
- `test-next` job: Fails immediately on first system test failure

This caused "one passes, one fails" scenarios where transient system test failures would be retried and pass in the main job but immediately fail the next job.

## Solution

Added identical retry logic to `system-test-next`:
- `continue-on-error: true` on initial test run
- Automatic retry with `--verbose` flag if first attempt fails
- Screenshot upload on failures (matching main job behavior)  
- Job only fails if both attempts fail

## Impact

- Eliminates false negatives from transient system test failures
- Both CI jobs now handle flaky tests consistently
- Maintains existing retry behavior that already works well in main job

## Testing

All pre-push hooks passed including full system test suite locally.