### PR TITLE
Add fallback to compare previous commit in system test helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,5 +111,6 @@ __pycache__/
 *.jsonl
 *.md
 *.sh
+!scripts/*.sh
 *.txt
 *.yml

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -158,6 +158,10 @@ pre-push:
         if [ -f .env ]; then
           . ./.env
         fi
+        if ./scripts/should-run-system-tests.sh; then
+          echo "⏭️  Skipping system tests (safe changes only)"
+          exit 0
+        fi
         echo "🚀 Setting up system test environment..."
         if ! CI=true RAILS_ENV=test mise exec -- bin/setup --skip-server; then
           echo "❌ Failed to set up system test environment"

--- a/scripts/should-run-system-tests.sh
+++ b/scripts/should-run-system-tests.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Determine the reference to compare against for the upcoming push.
+DIFF_BASE=""
+
+if git rev-parse --verify HEAD@{upstream} >/dev/null 2>&1; then
+  DIFF_BASE="HEAD@{upstream}"
+elif git rev-parse --verify origin/develop >/dev/null 2>&1; then
+  DIFF_BASE="$(git merge-base HEAD origin/develop 2>/dev/null || true)"
+  if [[ -z "$DIFF_BASE" ]]; then
+    echo "ℹ️  Unable to determine upstream comparison point."
+    echo "   Running system tests by default."
+    exit 1
+  fi
+elif git rev-parse --verify HEAD^ >/dev/null 2>&1; then
+  DIFF_BASE="HEAD^"
+else
+  echo "ℹ️  Unable to determine upstream comparison point."
+  echo "   Running system tests by default."
+  exit 1
+fi
+
+if [[ "$DIFF_BASE" == "HEAD^" ]]; then
+  echo "ℹ️  No upstream branch detected; comparing against the previous local commit."
+fi
+
+# Gather changed files (added, copied, modified, renamed) between DIFF_BASE and HEAD.
+mapfile -d '' -t CHANGED_FILES < <(git diff --name-only --diff-filter=ACMR -z "${DIFF_BASE}..HEAD")
+
+SAFE_PATTERNS=(
+  '^docs/'
+  '^\\.github/'
+  '^README\\.md$'
+  '^LICENSE$'
+  '^WARP\\.md$'
+  '^\\.rubocop\\.yml$'
+  '^\\.rubocop_todo\\.yml$'
+  '^\\.erb_lint\\.yml$'
+  '^\\.better-html\\.yml$'
+  '^\\.solargraph\\.yml$'
+  '^\\.prettier'
+  '^cspell\\.config\\.yaml$'
+  '^\\.gitignore$'
+  '^CODEOWNERS$'
+  '^\\.yarnrc\\.yml$'
+  '^static-analysis\\.datadog\\.yml$'
+  '^agent\\.prompt\\.yml$'
+  '^\\.pr-workflow\\.yml$'
+)
+
+if ((${#CHANGED_FILES[@]} == 0)); then
+  echo "✅ All changed files are safe (documentation/config only)"
+  echo "   Skipping system tests to save time"
+  exit 0
+fi
+
+for file in "${CHANGED_FILES[@]}"; do
+  file_safe=false
+  for pattern in "${SAFE_PATTERNS[@]}"; do
+    if [[ $file =~ $pattern ]]; then
+      file_safe=true
+      break
+    fi
+  done
+
+  if [[ $file_safe == false ]]; then
+    echo "🧪 Changed files may affect system behavior"
+    echo "   Running full system test suite"
+    exit 1
+  fi
+done
+
+echo "✅ All changed files are safe (documentation/config only)"
+echo "   Skipping system tests to save time"
+exit 0

--- a/scripts/should-run-system-tests.sh
+++ b/scripts/should-run-system-tests.sh
@@ -26,8 +26,8 @@ if [[ "$DIFF_BASE" == "HEAD^" ]]; then
   echo "ℹ️  No upstream branch detected; comparing against the previous local commit."
 fi
 
-# Gather changed files (added, copied, modified, renamed) between DIFF_BASE and HEAD.
-mapfile -d '' -t CHANGED_FILES < <(git diff --name-only --diff-filter=ACMR -z "${DIFF_BASE}..HEAD")
+# Gather changed files (including deletions) between DIFF_BASE and HEAD.
+mapfile -d '' -t CHANGED_FILES < <(git diff --name-only --diff-filter=ACDMR -z "${DIFF_BASE}..HEAD")
 
 SAFE_PATTERNS=(
   '^docs/'


### PR DESCRIPTION
## Summary
- fall back to comparing against the previous local commit when no upstream branch is available so the helper still inspects recent changes
- echo the fallback decision to clarify how the diff base was chosen

## Testing
- bash -n scripts/should-run-system-tests.sh

------
https://chatgpt.com/codex/tasks/task_e_6907fd41cf4c8321a5e36e2fa6e12aa8