### PR TITLE
Fix shop-info panel dark mode styling

### DIFF
--- a/app/assets/stylesheets/coffeeshops.scss
+++ b/app/assets/stylesheets/coffeeshops.scss
@@ -21,7 +21,9 @@
 
   .card-title,
   .card-title a {
-    color: var(--color-text) !important; // ensure shop name contrasts with dark backgrounds
+    color: var(
+      --color-text
+    ) !important; // ensure shop name contrasts with dark backgrounds
   }
 
   .card-action {
@@ -38,7 +40,14 @@
   margin-bottom: 60px;
 }
 .shop-info {
-  border: #302b2b solid 1px;
+  border: 1px solid color-mix(in srgb, var(--color-text) 12%, transparent);
   border-radius: 15px;
   padding: 20px;
+  background-color: color-mix(
+    in srgb,
+    var(--color-bg) 94%,
+    var(--color-text) 6%
+  );
+  color: var(--color-text);
+  box-shadow: none !important; // z-depth shadow looked gray on dark backgrounds
 }

--- a/app/views/coffeeshops/show.html.erb
+++ b/app/views/coffeeshops/show.html.erb
@@ -10,7 +10,7 @@
             </div>
             <!-- Coffeeshop Info -->
             <div class="col s12 l6">
-            <div class="shop-info z-depth-1">
+            <div class="shop-info">
                 <span>
                     <address class="card-action columns-2">
                             <%= link_to  "https://www.google.com/maps/search/?api=1&query=#{@coffeeshop.google_address_slug}",

--- a/test/system/dark_mode_test.rb
+++ b/test/system/dark_mode_test.rb
@@ -27,6 +27,11 @@ class DarkModeTest < ApplicationSystemTestCase
 
     assert_equal 'rgb(18, 52, 86)', page_name_color
 
+    shop_info_shadow =
+      page.evaluate_script('window.getComputedStyle(document.querySelector(".shop-info")).boxShadow')
+
+    assert_equal 'none', shop_info_shadow
+
     capture_show_page if capture_dark_mode?
   end
 
@@ -52,11 +57,11 @@ class DarkModeTest < ApplicationSystemTestCase
 
   def capture_search_results
     set_theme_text('#ffffff')
-    page.save_screenshot(Rails.root.join('tmp', 'dark-mode-search.png'), full: true)
+    page.save_screenshot(Rails.root.join('tmp/dark-mode-search.png'), full: true)
   end
 
   def capture_show_page
     set_theme_text('#ffffff')
-    page.save_screenshot(Rails.root.join('tmp', 'dark-mode-show.png'), full: true)
+    page.save_screenshot(Rails.root.join('tmp/dark-mode-show.png'), full: true)
   end
 end


### PR DESCRIPTION
## Summary
- Remove z-depth-1 class from shop-info div to eliminate unwanted shadow
- Add dark mode aware styling: dynamic border, background, and text colors  
- Add box-shadow: none to prevent Material Design shadows in dark mode
- Add system test assertion to verify box-shadow removal

## Changes
- **app/assets/stylesheets/coffeeshops.scss**: Override .shop-info styling with dark mode color variables
- **app/views/coffeeshops/show.html.erb**: Remove z-depth-1 class from shop-info div
- **test/system/dark_mode_test.rb**: Add assertion for box-shadow: none

## Test Plan
- All system tests pass (28 runs, 124 assertions)
- All unit tests pass (60 runs, 162 assertions)
- Tailwind build verification passed
- Dark mode visual verification completed

The shop-info panel now seamlessly adapts to dark mode with proper color blending and no Material Design shadows.