### PR TITLE
Clarify agent responsibility for routine commands

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,11 @@ For deep policy and methodology, see `docs/AGENTS.md`.
 - **Use the mise toolchain**
   - Prefix all runtime commands with:
     - `mise exec -- <command>`
-  - This matches CI and Git hooks and avoids environment mismatches.
+  - Prefer named mise tasks over raw commands when they exist, for example:
+    - `mise run test` instead of manually invoking the full Rails test suite command
+    - `mise run test-system` for system tests
+    - `mise run brakeman` for security scans
+  - Treat `WARP.md` and `mise.toml` as the source of truth for the authoritative list of mise tasks used by CI and hooks.
 
 - **Never bypass hooks**
   - Do **not** use `--no-verify` with Git.


### PR DESCRIPTION
Clarify project-wide agent behavior so agents run routine commands themselves instead of asking the user.

Changes:
- Update AGENTS.md core runtime rules to explicitly state that agents SHOULD:
  - Run common commands (git status/add/push, mise exec -- ./scripts/..., etc.) autonomously via tools/CLI.
  - Avoid asking the user to manually run simple commands.
- Document the only exceptions as actions requiring interactive secrets/credentials or explicit human sign-off for risky/destructive operations.

This PR only touches AGENTS.md (no runtime code changes).