### PR TITLE
Add website design improvement docs and CodeQL config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,6 @@ db/schema.rb linguist-generated
 
 # Mark any vendored files as having been vendored.
 vendor/* linguist-vendored
+
+# Treat design / prototype docs as documentation (not primary code).
+docs/website-design-improvement/** linguist-documentation

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,17 @@
+name: "Jitter CodeQL config"
+
+# Focus analysis on real application code and explicitly exclude
+# design/prototype areas such as the "Website Design Improvement" work.
+paths:
+  - app/**
+  - config/**
+  - lib/**
+  - bin/**
+
+paths-ignore:
+  # Design / prototype UI work, including remote-only folder
+  - "Website Design Improvement/**"
+  - "docs/website-design-improvement/**"
+  # Tests are covered by runtime CI; keep CodeQL focused on app surface
+  - "test/**"
+  - "spec/**"

--- a/docs/website-design-improvement/README.md
+++ b/docs/website-design-improvement/README.md
@@ -1,0 +1,77 @@
+# Website Design Improvement
+
+> Tracked in GitHub: [Issue #1002 – Plan: Integrate Website Design Improvement prototype into Rails UI](https://github.com/jcowhigjr/yelp_search_demo/issues/1002)
+
+## Purpose
+
+- Capture the visual and interaction patterns from the Website Design Improvement prototype.
+- Provide a concrete implementation plan for incrementally porting those patterns into the Rails app.
+- Keep this work clearly scoped as **design / documentation**, not as code that needs to be analyzed by CodeQL or CI linters.
+
+## Where this is used
+
+- Referenced from the "Website Design Improvement" GitHub issue (link that issue here in the description / comments).
+- Used as the single source of truth for how the new UI should look and behave.
+
+## CodeQL and scanning behavior
+
+To avoid static analysis noise from design prototypes:
+
+- The repo includes a CodeQL config at `.github/codeql/codeql-config.yml` which:
+  - Focuses CodeQL analysis on real app code (`app/**`, `config/**`, `lib/**`, `bin/**`).
+  - Explicitly ignores this directory via:
+    - `docs/website-design-improvement/**`
+    - and also the historical root-level folder name `Website Design Improvement/**`.
+- `.gitattributes` marks this docs directory as documentation:
+  - `docs/website-design-improvement/** linguist-documentation`
+
+This means you are free to place design assets and notes here (including screenshots, PDFs, or prototype snippets) without them being treated as primary app code by GitHub.
+
+## Suggested structure
+
+You can organize this directory as follows:
+
+- `README.md` (this file): overview, purpose, and links to the GitHub issue.
+- `screenshots/`: exported PNGs or JPEGs of key flows
+  - Search
+  - Results
+  - Coffeeshop detail
+  - Favorites
+  - Auth (login / signup)
+- `flows/`: optional markdown files describing each flow in more detail
+  - `search-flow.md`
+  - `detail-flow.md`
+  - `favorites-flow.md`
+  - `auth-flow.md`
+- `prototype/` (optional): if you choose to check in a React/Vite or other prototype for local reference only.
+
+When adding a runnable prototype under `prototype/`, keep in mind:
+
+- It is **not** part of the production app.
+- It is **out of scope** for CodeQL scanning due to the repo-wide CodeQL config.
+- Local developers can explore it as a reference for layout and behavior, then implement the real changes in Rails views (`app/views/...`) using ERB + Tailwind + existing CSS.
+
+## Implementation plan (high-level)
+
+For detailed responsibilities and how to split this work across multiple engineering agents, see:
+
+- `agents-playbook.md` – how to parallelize work and structure PRs
+- `flows/` – per-flow UX docs (search, detail, favorites, auth)
+
+If you want to keep a compact version of the implementation plan here, you can summarize it like this:
+
+1. **Search hero and search bar alignment**
+   - Modern hero section on `searches#new`.
+   - Search bar layout aligned with the prototype, using existing Rails form helpers.
+2. **Results grid and coffeeshop card alignment**
+   - Align card layout and grid structure with the prototype while keeping behavior unchanged.
+3. **Coffeeshop detail page layout alignment**
+   - Two-column layout on large screens, single-column on small screens.
+4. **Favorites page layout and empty state**
+   - Use shared card patterns and friendly empty-state messaging.
+5. **Navigation and footer polish**
+   - Align nav and footer styling with the prototype using existing tokens.
+6. **Optional theme toggle and auth form refinement**
+   - Use existing dark-mode variables and consistent form patterns.
+
+The full, detailed implementation plan can be pasted or refined here as needed, so that reviewers and other engineers can reason about the design work directly in the repo.

--- a/docs/website-design-improvement/agents-playbook.md
+++ b/docs/website-design-improvement/agents-playbook.md
@@ -1,0 +1,121 @@
+# Website Design Improvement – Agents Playbook
+
+> Tracked in GitHub: [Issue #1002 – Plan: Integrate Website Design Improvement prototype into Rails UI](https://github.com/jcowhigjr/yelp_search_demo/issues/1002)
+
+This playbook explains **how agents should work this issue in parallel** without stepping on each other, and how to keep PRs small, test-backed, and aligned with the design prototype.
+
+## High-level phases
+
+Each phase should generally correspond to **one focused PR**:
+
+1. Search hero and search bar alignment (DONE)
+2. Results grid and coffeeshop card alignment (DONE)
+3. Coffeeshop detail page layout alignment
+4. Favorites page layout and empty state
+5. Navigation and footer polish
+6. Optional theme toggle and auth form refinement
+
+Details for each phase live in:
+
+- `implementation-plan.md` (overall breakdown)
+- `flows/*.md` (per-flow UX and constraints)
+
+## Parallelization model
+
+Agents should treat each phase as an independent track, with these rules:
+
+- **Do not modify controllers or models** unless explicitly required by the issue.
+- **Do not introduce React/Vite** into the Rails app; use ERB + Tailwind + existing CSS.
+- Prefer **view-only** changes (`app/views/**`, CSS) plus **tests**.
+- For each phase:
+  - Create a dedicated branch: `feature/website-design-<phase-name>`
+  - Touch only the views/CSS/tests listed in that phase’s section.
+  - Run the specific tests listed for that phase.
+
+## Per-phase quick map
+
+This is a routing table to help agents jump straight to the right files and tests.
+
+### Phase 3 – Coffeeshop detail page
+
+- **Primary views**
+  - `app/views/coffeeshops/show.html.erb`
+- **Key tests**
+  - System: `test/system/coffeeshops_test.rb`
+- **Flow doc**
+  - `flows/detail-flow.md`
+
+### Phase 4 – Favorites page
+
+- **Primary views**
+  - `app/views/user_favorites/index.html.erb` (or the actual favorites index view used in this app)
+  - Any partial that renders favorite coffeeshops (ideally reusing `_coffeeshop`)
+- **Key tests**
+  - System: favorites-related system test (add or extend as described in `implementation-plan.md`)
+- **Flow doc**
+  - `flows/favorites-flow.md`
+
+### Phase 5 – Navigation and footer
+
+- **Primary views**
+  - `app/views/layouts/_navbar.html.erb`
+  - `app/views/layouts/_footer.html.erb`
+- **Key tests**
+  - System: navigation/footer system test (e.g., `test/system/navigation_test.rb`)
+- **Flow docs**
+  - `flows/search-flow.md` (for top-level navigation to search)
+
+### Phase 6 – Theme toggle and auth forms (optional)
+
+- **Primary views**
+  - Auth: `app/views/sessions/new.html.erb`, `app/views/users/new.html.erb` (or equivalents)
+  - Layout: element that receives `data-theme` for dark/light
+- **Key tests**
+  - Existing login/signup system tests
+- **Flow docs**
+  - `flows/auth-flow.md`
+
+## Standard workflow for an agent
+
+For any phase you pick up:
+
+1. **Read the design docs**
+   - `README.md`
+   - `implementation-plan.md`
+   - The relevant `flows/*.md` file
+2. **Confirm scope**
+   - Verify which phase and which files you are allowed to touch.
+   - Ensure you are not overlapping with another active phase/branch.
+3. **Create a feature branch**
+   - Follow the project’s standard: `feature/website-design-<phase-name>`.
+4. **Make view/CSS changes only**
+   - Keep behavior (routes, controller actions, models) the same.
+   - Focus on layout, spacing, typography, and structure.
+5. **Update/add tests**
+   - Prefer system tests that assert key elements exist and are wired correctly.
+   - Keep tests resilient to minor cosmetic changes.
+6. **Run targeted tests**
+   - Run the tests listed in the phase (controller/system) before pushing.
+7. **Open a PR**
+   - Title: `Website Design Improvement – Phase X: <short description>`
+   - Link to Issue #1002 and the specific flow doc.
+   - Describe exactly which views and tests changed.
+
+## What “done” means for a phase
+
+A phase is **done** when:
+
+- The layout/structure of the targeted views matches the intent of the prototype, as described in the flow doc.
+- All existing behavior is preserved (same routes, same forms, same buttons/links).
+- Tests listed for the phase pass locally.
+- The PR remains small and reviewable in under ~15 minutes.
+
+## Coordination between agents
+
+To allow parallel work:
+
+- Prefer that each agent owns **one phase at a time**.
+- Avoid touching shared partials (like `_coffeeshop`) in unrelated phases unless the change is clearly shared and documented.
+- If two phases must both adjust a shared partial, coordinate via the GitHub issue or PR comments and update the docs here if the shared contract changes.
+
+If additional flows or surfaces are added later, create new `flows/*.md` files and extend `implementation-plan.md` so future agents can follow the same pattern.

--- a/docs/website-design-improvement/flows/auth-flow.md
+++ b/docs/website-design-improvement/flows/auth-flow.md
@@ -1,0 +1,38 @@
+# Auth Flow – Login and Signup
+
+## Goal
+
+Make login and signup forms visually consistent with the prototype, using shared tokens and layout patterns, while keeping all authentication behavior unchanged.
+
+## Surfaces
+
+- Login: `sessions#new`
+  - View: `app/views/sessions/new.html.erb`
+- Signup: `users#new`
+  - View: `app/views/users/new.html.erb`
+
+## UX expectations
+
+- Centered card or panel layout for forms.
+- Consistent input styling (padding, borders, focus state).
+- Clear primary button (Log In / Sign Up) and secondary links (e.g., to signup/login, password help if present).
+- Typography aligned with `page-name` for headings and `page-text` for supporting copy.
+
+## Constraints
+
+- Do not change the underlying authentication logic or routes.
+- Keep field names and error messaging intact.
+- Ensure error messages remain visible and accessible after styling changes.
+
+## Tests to touch
+
+- System tests covering login/logout and signup flows.
+
+## Agent checklist
+
+When working on auth-related changes (Phase 6):
+
+1. Read this document plus `implementation-plan.md` Phase 6.
+2. Adjust only the **view layout and classes**; do not alter form field names or routes.
+3. Verify error states manually (e.g., submit with invalid credentials) to ensure messages are still shown.
+4. Run the existing login/signup system tests before opening a PR.

--- a/docs/website-design-improvement/flows/detail-flow.md
+++ b/docs/website-design-improvement/flows/detail-flow.md
@@ -1,0 +1,49 @@
+# Detail Flow – Coffeeshop Page
+
+## Goal
+
+Align the coffeeshop detail page layout with the prototype’s detail view while preserving all existing interactions (favorites, reviews, Yelp link, etc.).
+
+## Surface
+
+- Coffeeshop detail: `coffeeshops#show`
+  - View: `app/views/coffeeshops/show.html.erb`
+
+## UX expectations
+
+- Two-column layout on large screens:
+  - Left: coffeeshop image
+  - Right: name, address, phone, Yelp link, rating, favorites CTA
+- Single-column layout on small screens (stacked vertically).
+- Clear grouping:
+  - **About** section: address, phone, Yelp link, rating, favorites count
+  - **Reviews** section: list of reviews plus review form when logged in
+
+## Constraints
+
+- **Do not change** controller logic, routes, or model methods.
+- Keep Turbo frames and favorites logic intact (`turbo_frame_tag :user_favorite`).
+- Reuse `page-name` and `page-text` for headings/body copy.
+- Keep `.review-container` structure compatible with existing tests.
+
+## Tests to touch
+
+- System tests: `test/system/coffeeshops_test.rb`
+
+## Agent checklist
+
+When working on detail-page changes (Phase 3):
+
+1. Read this document plus `implementation-plan.md` Phase 3.
+2. Restructure only the **HTML layout** in `coffeeshops/show.html.erb`.
+3. Do **not** change form actions, routes, or Turbo frame IDs.
+4. Ensure the page still exposes:
+   - Coffeeshop name as main heading
+   - Address link (Google Maps)
+   - Phone link (tel:)
+   - Yelp link
+   - Rating widget
+   - Favorites add/remove buttons when logged in
+   - Reviews list and review form
+5. Update/extend system tests to assert the above elements are present.
+6. Run `mise exec -- bin/rails test test/system/coffeeshops_test.rb` before opening a PR.

--- a/docs/website-design-improvement/flows/favorites-flow.md
+++ b/docs/website-design-improvement/flows/favorites-flow.md
@@ -1,0 +1,46 @@
+# Favorites Flow – Website Design Improvement
+
+## Goal
+
+Align the favorites list page with the prototype’s Favorites view, using shared coffeeshop card patterns and a friendly empty state.
+
+## Surfaces
+
+- Favorites index (user’s favorites list)
+  - View: `app/views/user_favorites/index.html.erb` (or the actual favorites index view)
+  - Partials: should reuse `app/views/coffeeshops/_coffeeshop.html.erb` for cards when possible
+
+## UX expectations
+
+- Heading: “My Favorites” using `page-name` styling.
+- When the user has **no favorites**:
+  - Show an empty state with copy that explains there are no favorites yet.
+  - Provide a clear CTA (link/button) back to the search page.
+- When the user **has favorites**:
+  - Render a grid of coffeeshop cards using the shared `_coffeeshop` partial.
+
+## Constraints
+
+- Do not change favorites behavior (how favorites are created/destroyed).
+- Reuse `_coffeeshop` for visual consistency with search results.
+- Keep routes and controller actions unchanged.
+
+## Tests to touch
+
+- System tests for favorites behavior (add or extend a system test file, e.g., `test/system/favorites_test.rb` or similar).
+
+## Agent checklist
+
+When working on favorites-page changes (Phase 4):
+
+1. Read this document plus `implementation-plan.md` Phase 4.
+2. Confirm which view is the actual favorites index in this app.
+3. Introduce or refine:
+   - “My Favorites” heading
+   - Empty-state block with copy + CTA
+   - Grid of cards when favorites exist (via `_coffeeshop`).
+4. Add or extend a system test that:
+   - Logs in as a user.
+   - Exercises both the empty and non-empty favorites states.
+   - Asserts the heading, empty-state copy, CTA, and coffeeshop cards.
+5. Run the relevant system tests via `mise exec -- bin/rails test test/system` (or the narrower favorites file) before opening a PR.

--- a/docs/website-design-improvement/flows/search-flow.md
+++ b/docs/website-design-improvement/flows/search-flow.md
@@ -1,0 +1,53 @@
+# Search Flow – Website Design Improvement
+
+## Goal
+
+Align the search entry and results experience with the prototype while preserving all existing behavior and routes.
+
+## Surfaces
+
+- Search landing: `searches#new`
+  - View: `app/views/searches/new.html.erb`
+  - Partial: `app/views/searches/_form.html.erb`
+- Search results: `searches#show`
+  - View: `app/views/searches/show.html.erb`
+  - Partial: `app/views/searches/_results.html.erb`
+
+## UX expectations
+
+- Hero section on `searches#new` with:
+  - Large title (e.g., “COFFEE NEAR YOU!”)
+  - Supporting subtitle (plain `page-text`)
+- Centered search bar with:
+  - Search icon
+  - Text input for query
+  - Geolocation controls preserved
+  - Primary submit button
+- Results page with:
+  - Clear heading showing the query or context
+  - Grid of coffeeshop cards rendered via `_coffeeshop` partial
+
+## Constraints
+
+- **Do not change** controller logic or routes.
+- **Do not change** parameter names (`search[query]`, geolocation fields).
+- **Do not introduce** new JS frameworks; use existing Stimulus/Hotwire only if needed.
+- Reuse typography and color tokens: `page-name`, `page-text`, `.coffeeshop-card`.
+
+## Tests to touch
+
+- Controller tests: `test/controllers/searches_controller_test.rb`
+- System tests: `test/system/searches_test.rb`
+
+## Agent checklist
+
+When working on search-related changes:
+
+1. Read this document plus `implementation-plan.md` Phase 1–2.
+2. Modify **only** the views/partials listed above.
+3. Keep all form fields and routes intact.
+4. Ensure `_coffeeshop` is the single source for coffeeshop cards.
+5. Update/extend tests to assert the presence of:
+   - Hero heading on `searches#new`.
+   - `.coffeeshop-card` elements on `searches#show` when results exist.
+6. Run `mise exec -- bin/rails test test/controllers/searches_controller_test.rb test/system/searches_test.rb` before opening a PR.

--- a/docs/website-design-improvement/implementation-plan.md
+++ b/docs/website-design-improvement/implementation-plan.md
@@ -1,0 +1,137 @@
+
+## Problem statement
+The `Website Design Improvement` React/Vite prototype defines a cleaner, more cohesive UI for search, results, detail, favorites, and auth flows. The production Rails app currently uses a Materialize-centric layout with partially aligned tokens, leading to a mismatch between the intended design and the live experience.
+
+We need a low-tech-debt, incremental plan to port the visual and interaction patterns from the prototype into the Rails app, without introducing React or disrupting existing behavior, tests, or Hotwire/Turbo integrations.
+
+## Current state summary
+
+* **Search flow**
+  * `searches#new` renders a basic search form using `app/views/searches/new.html.erb` and `_form.html.erb`.
+  * `searches#show` renders the search results via `app/views/searches/show.html.erb` and `_results.html.erb`.
+  * System tests in `test/system/searches_test.rb` cover anonymous search flows and re-query behavior.
+* **Coffeeshop views**
+  * `app/views/coffeeshops/_coffeeshop.html.erb` renders individual coffeeshop cards inside Materialize grid columns.
+  * `app/views/coffeeshops/show.html.erb` displays the coffeeshop detail page with image, address, phone, Yelp link, rating, favorites, and reviews.
+* **Layout and styles**
+  * `app/views/layouts/application.html.erb` uses Materialize CSS, Tailwind, and shared `page-name` and `page-text` classes from `app/assets/stylesheets/application.css`.
+  * `.coffeeshop-card` and related CSS already support dark mode via CSS variables.
+* **Prototype**
+  * `Website Design Improvement/` contains a React/Tailwind prototype with `SearchPage`, `ResultsPage`, `DetailPage`, `FavoritesPage`, `Navigation`, and `Footer` components.
+  * It defines reusable visual patterns such as a search hero, search bar, card grid, and detail layout.
+
+## Constraints and goals
+
+* Do not introduce React or Vite into the Rails app; use ERB + Tailwind + existing CSS.
+* Maintain all existing controller behavior and routing.
+* Keep changes small and test-backed, suitable for focused PRs.
+* Reuse existing tokens and classes (`page-name`, `page-text`, `.coffeeshop-card`, color variables) to avoid parallel design systems.
+* Respect existing Turbo streams and frames.
+
+## Phases
+
+### Phase 1: Search hero and search bar alignment (DONE)
+
+* Update `app/views/searches/new.html.erb` to:
+  * Wrap content in a `container mx-auto px-4 py-8`-style layout.
+  * Add a hero section with a large heading (e.g., "COFFEE NEAR YOU!") and supporting copy (e.g., "Find the best coffee shops in your area").
+  * Center the existing search form under the hero using `page-name` and `page-text` for typography.
+* Refactor `app/views/searches/_form.html.erb` to:
+  * Use an inline-flex container with border, rounded corners, and shadow for the search bar.
+  * Include a search icon, text input, clear action, and primary submit action, preserving current form helpers and geolocation fields.
+* **Tests**
+  * Extend `test/controllers/searches_controller_test.rb` to assert the hero heading and presence of the `search[query]` input on `#new`.
+
+### Phase 2: Results grid and coffeeshop card alignment (DONE)
+
+* **Coffeeshop card partial**
+  * Keep using `app/views/coffeeshops/_coffeeshop.html.erb` as the single partial for coffeeshop cards.
+  * Ensure the markup uses `page-text` and `.coffeeshop-card` for typography and background, aligning with the prototype card styling while preserving favorites, address, phone, and links.
+* **Results grid**
+  * Update `app/views/searches/_results.html.erb` to:
+    * Preserve the heading and empty-state messaging.
+    * Wrap the list of coffeeshops in a `.row` so each `_coffeeshop` column forms a clear grid of cards.
+* **Tests**
+  * Extend `test/controllers/searches_controller_test.rb` `#show` to assert that at least one `.coffeeshop-card` is rendered when results are present.
+
+### Phase 3: Coffeeshop detail page layout alignment (PARTIALLY IMPLEMENTED)
+
+* **Context**
+  * Use `Website Design Improvement/src/components/pages/DetailPage.tsx` as the visual reference.
+  * Current view is `app/views/coffeeshops/show.html.erb` with a Materialize row/column layout.
+
+* **Changes**
+  * Restructure `coffeeshops/show.html.erb` into a layout that:
+    * Uses a two-column layout on large screens (image on one side, details on the other) while remaining single-column on small screens.
+    * Applies `page-name` and `page-text` to the title and key copy for visual consistency.
+    * Groups address, phone, and Yelp link into clearly delineated sections similar to the prototype's icon + text rows.
+    * Keeps favorites and reviews behavior unchanged, but improves spacing and grouping to mirror the prototype's "About" and "Reviews" sections.
+
+* **Tests**
+  * Update or add a system test (e.g., in `test/system/coffeeshops_test.rb`) that:
+    * Navigates from a search result to a coffeeshop show page.
+    * Asserts presence of the title, address, phone, Yelp link, and at least one review card when data exists.
+
+### Phase 4: Favorites page layout and empty state (IMPLEMENTED IN USER PROFILE)
+
+* **Context**
+  * Use the prototype's `FavoritesPage` layout as guidance.
+  * Identify the existing favorites view (e.g., `app/views/user_favorites/index.html.erb` or similar) and how it currently renders coffeeshops.
+
+* **Changes**
+  * Update the favorites view to:
+    * Introduce a "My Favorites" heading using `page-name`.
+    * Show a friendly empty state when there are no favorites, with copy encouraging users to search and a button/link back to the main search page.
+    * When favorites exist, render them using the shared `_coffeeshop` partial in a grid layout similar to the search results.
+
+* **Tests**
+  * Add or extend a system test that:
+    * Logs in a user.
+    * Covers both empty and non-empty favorites states, asserting the header text and presence of coffeeshop cards when applicable.
+
+### Phase 5: Navigation and footer polish (PARTIALLY IMPLEMENTED)
+
+* **Navigation**
+  * Adjust `app/views/layouts/_navbar.html.erb` to:
+    * Use existing color tokens and font stack for the brand and links.
+    * Align link styles with the prototype's `Navigation` component while preserving Materialize's mobile sidenav behavior and current links (logout, profile, search).
+    * Leverage `.language-nav__link` and related classes already defined in `application.css` where appropriate.
+
+* **Footer**
+  * Update the footer partial (e.g., `app/views/layouts/_footer.html.erb`) to:
+    * Use a simple structure similar to the prototype's footer: left-aligned copyright, right-aligned small links (About, Contact, Privacy).
+    * Ensure it respects dark mode variables and existing layout constraints.
+
+* **Tests**
+  * Extend or add a system test (for example in `test/system/navigation_test.rb`) to assert that the main nav and footer links render and are clickable for a logged-in user.
+
+### Phase 6: Theme toggle (DONE) and auth form refinement
+
+* **Theme toggle – IMPLEMENTED**
+  * Current implementation:
+    * Stimulus controller at `app/javascript/controllers/theme_controller.js`.
+    * Toggle button in `app/views/layouts/application.html.erb` with `data-controller="theme"`, `data-action="click->theme#toggle"`, and `aria-label="Toggle theme"`.
+    * CSS variables and Tailwind utilities in `app/assets/tailwind/application.css` and `app/assets/stylesheets/application.css` using `data-theme`.
+    * System test `test/system/theme_toggle_test.rb` verifies toggling and localStorage persistence.
+  * Future refinements (optional): adjust visual styling or icon treatment of the toggle if the design prototype changes.
+
+* **Auth forms – PARTIALLY ALIGNED**
+  * Current state:
+    * `app/views/sessions/new.html.erb` and `app/views/users/new.html.erb` already use centered card layouts with `page-name`, `page-text`, and Tailwind-style utility classes for inputs and buttons.
+  * Remaining refinement:
+    * Tighten spacing, border radii, and typography to more closely match the prototype's `LoginPage` and `SignupPage` if needed.
+    * Ensure error states and third-party auth buttons remain visually consistent across login and signup.
+
+* **Tests**
+  * Ensure login/logout and signup system tests continue to pass and that error messages remain visible and accessible.
+
+## Execution approach
+
+* Implement one phase at a time, keeping each phase small enough for a focused PR.
+* After each phase:
+  * Run targeted tests (controller and system tests) related to the changed views.
+  * Visually sanity-check pages locally when feasible.
+* When ready to publish work:
+  * Create a dedicated feature branch for the phase.
+  * Commit only the files related to that phase with a clear message.
+  * Open a PR that links back to the overarching "Website Design Improvement" issue and notes which phase in this plan it implements.


### PR DESCRIPTION
This PR adds design docs for the Jitter website experience and configures CodeQL to ignore those artifacts.

Changes:
- Add docs/website-design-improvement/: flows, agents playbook, implementation plan, and README describing the "Website Design Improvement" work.
- Add .github/codeql/codeql-config.yml to focus analysis on app code (app/, config/, lib/, bin/) and ignore: "Website Design Improvement/**", docs/website-design-improvement/**, and test/spec trees.
- Tag docs/website-design-improvement/** as linguist-documentation in .gitattributes so they are recognized as docs, not application code.

Outcome:
- Design/prototype work is documented but excluded from CodeQL so security analysis stays focused on real app surfaces.