### PR TITLE
[DRAFT] Fix #1096

### DIFF
--- a/test/system/locales_test.rb
+++ b/test/system/locales_test.rb
@@ -77,4 +77,42 @@ class LocalesTest < ApplicationSystemTestCase
 
     assert_selector "input[placeholder='Rechercher des cafés...']"
   end
+
+  test 'language selector interaction switches to French locale' do
+    # Visit homepage and verify initial English locale
+    visit '/'
+    
+    # Verify initial page loads with html[lang="en"]
+    assert_equal 'en', page.find('html')['lang'], "Expected html[lang='en'] on initial load"
+    
+    # Verify English heading is present (New Search page)
+    assert_selector 'h2', text: 'New Search'
+    
+    # Verify English search placeholder
+    assert_selector "input[placeholder='Search for coffee shops...']"
+    
+    # Locate and click the French language selector in footer
+    within 'footer .language-nav' do
+      # Find the French language link by text content
+      french_link = find('a', text: 'Français')
+      # Click and wait for page to reload
+      french_link.click
+    end
+    
+    # Wait for page to finish loading after navigation
+    # Check the URL to confirm we navigated to /fr
+    assert_current_path '/fr'
+    
+    # Verify page updates to html[lang="fr"] after language switch
+    assert_equal 'fr', page.find('html')['lang'], "Expected html[lang='fr'] after clicking French selector"
+    
+    # Verify French search placeholder is displayed
+    assert_selector "input[placeholder='Rechercher des cafés...']", wait: 5
+    
+    # Verify French language link has active class
+    within 'footer .language-nav' do
+      french_link = find('a', text: 'Français')
+      assert french_link[:class].include?('language-nav__link--active'), "Expected French link to have active class"
+    end
+  end
 end


### PR DESCRIPTION
Automated solution for issue #1096

**Status**: Tests failed

Test output:
```
Running 63 tests in parallel using 3 processes
Run options: --seed 8173

# Running:

...............................................................

Finished in 1.708694s, 36.8703 runs/s, 99.4912 assertions/s.
63 runs, 170 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 0.95 seconds
Running 33 tests in parallel using 3 processes
Run options: --seed 52360

# Running:

SSS[Screenshot Image]: tmp/capybara/screenshots/failures_test_sign_in_and_visit_user_profile.png 
.SE

Error:
UsersTest#test_sign_in_and_visit_user_profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/users_test.rb:43:in `block in <class:UsersTest>'

bin/rails test test/system/users_test.rb:32

..[Screenshot Image]: tmp/capybara/screenshots/failures_test_I_should_login_and_see_My_Profile.png 
E

Error:
LoginTest#test_I_should_login_and_see_My_Profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/login_test.rb:19:in `block in <class:LoginTest>'

bin/rails test test/system/sessions/login_test.rb:8

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:17:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:81:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:72

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:18:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:9

[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/coffeeshops_test.rb:129:in `block in <class:CoffeeshopsTest>'

bin/rails test test/system/coffeeshops_test.rb:121

.......S..[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:16:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4

......

Finished in 449.882082s, 0.0734 runs/s, 0.1978 assertions/s.
33 runs, 89 assertions, 0 failures, 7 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m271ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m215ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m257ms[39m

```

Agent results:
- **backend**: Completed via Warp CLI: 1 file(s) changed
