### PR TITLE
[DRAFT] Fix #1095

### DIFF
--- a/test/system/locales_test.rb
+++ b/test/system/locales_test.rb
@@ -5,25 +5,15 @@ class LocalesTest < ApplicationSystemTestCase
   test 'the language selector shows all available locales' do
     visit '/'
     
-    # Check if new language selector button exists (future implementation)
-    if has_selector?('button[aria-haspopup]', wait: 0)
-      # New language selector: test dropdown functionality
-      find('button[aria-haspopup]').click
-      
-      # Verify all language options are present in the dropdown
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'English'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Português'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Français'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Español'
-    else
-      # Current implementation: test footer links
-      within 'footer' do
-        assert_selector 'a', text: 'English'
-        assert_selector 'a', text: 'Português'
-        assert_selector 'a', text: 'Français'
-        assert_selector 'a', text: 'Español'
-      end
-    end
+    # Find and click the language selector button
+    assert_selector 'button[aria-haspopup="true"]'
+    find('button[aria-haspopup="true"]').click
+    
+    # Verify all language options are present in the dropdown
+    assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'English'
+    assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Português'
+    assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Français'
+    assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Español'
    end
 
 


### PR DESCRIPTION
Automated solution for issue #1095

**Status**: Tests failed

Test output:
```
Running 63 tests in parallel using 3 processes
Run options: --seed 1088

# Running:

...............................................................

Finished in 2.003097s, 31.4513 runs/s, 84.8686 assertions/s.
63 runs, 170 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 0.95 seconds
Running 32 tests in parallel using 3 processes
Run options: --seed 7981

# Running:

.....[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:16:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:17:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8

...[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/coffeeshops_test.rb:129:in `block in <class:CoffeeshopsTest>'

bin/rails test test/system/coffeeshops_test.rb:121

S.SS.S.S....[Screenshot Image]: tmp/capybara/screenshots/failures_test_When_I_log_out_I_can_not_leave_a_review.png 
E

Error:
LogoutTest#test_When_I_log_out_I_can_not_leave_a_review:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/logout_test.rb:23:in `block in <class:LogoutTest>'

bin/rails test test/system/sessions/logout_test.rb:14

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_the_language_selector_shows_all_available_locales.png 
F

Failure:
LocalesTest#test_the_language_selector_shows_all_available_locales [test/system/locales_test.rb:9]:
expected to find css "button[aria-haspopup=\"true\"]" but there were no matches

bin/rails test test/system/locales_test.rb:5

...[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:81:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:72

[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:18:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:9



Finished in 443.786502s, 0.0721 runs/s, 0.1713 assertions/s.
32 runs, 76 assertions, 1 failures, 6 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m285ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m182ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m181ms[39m

```

Agent results:
- **backend**: Completed via Warp CLI: 1 file(s) changed
