### PR TITLE
[DRAFT] Fix #1093

### DIFF
--- a/app/views/layouts/_language_selector.html.erb
+++ b/app/views/layouts/_language_selector.html.erb
@@ -1,0 +1,28 @@
+<%# Language selector toggle button %>
+<div class="language-selector" data-controller="language-selector">
+  <button 
+    class="language-selector__toggle"
+    data-action="click->language-selector#toggle"
+    aria-label="<%= t('.select_language') %>"
+    aria-expanded="false"
+    type="button"
+  >
+    <i class="material-icons language-selector__icon">language</i>
+    <span class="language-selector__current"><%= I18n.locale.to_s.upcase %></span>
+    <i class="material-icons language-selector__arrow">arrow_drop_down</i>
+  </button>
+  
+  <div class="language-selector__dropdown" data-language-selector-target="dropdown" hidden>
+    <% I18n.available_locales.each do |locale| %>
+      <%= link_to request.params.merge(locale: resolve_locale(locale)),
+                  class: [
+                    'language-selector__option',
+                    ('language-selector__option--active' if locale == I18n.locale)
+                  ].compact.join(' '),
+                  data: { action: 'click->language-selector#select' } do %>
+        <span class="language-selector__locale-code"><%= locale.to_s.upcase %></span>
+        <span class="language-selector__locale-name"><%= t('.language_name_of_locale', locale: locale) %></span>
+      <% end %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
Automated solution for issue #1093

**Status**: Tests failed

Test output:
```
Running 63 tests in parallel using 3 processes
Run options: --seed 2291

# Running:

...............................................................

Finished in 2.378487s, 26.4874 runs/s, 71.4740 assertions/s.
63 runs, 170 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 0.98 seconds
Running 32 tests in parallel using 3 processes
Run options: --seed 63432

# Running:

SS.S[Screenshot Image]: tmp/capybara/screenshots/failures_test_sign_in_and_visit_user_profile.png 
E

Error:
UsersTest#test_sign_in_and_visit_user_profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/users_test.rb:43:in `block in <class:UsersTest>'

bin/rails test test/system/users_test.rb:32

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:17:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_submit_a_review.png 
F

Failure:
CoffeeshopsTest#test_A_logged_in_user_can_submit_a_review [test/system/coffeeshops_test.rb:72]:
expected to find css "input[type=\"submit\"][value=\"Remove From Favorites\"]" but there were no matches

bin/rails test test/system/coffeeshops_test.rb:49

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/coffeeshops_test.rb:129:in `block in <class:CoffeeshopsTest>'

bin/rails test test/system/coffeeshops_test.rb:121

[Screenshot Image]: tmp/capybara/screenshots/failures_test_When_I_log_out_I_can_not_leave_a_review.png 
E

Error:
LogoutTest#test_When_I_log_out_I_can_not_leave_a_review:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/logout_test.rb:23:in `block in <class:LogoutTest>'

bin/rails test test/system/sessions/logout_test.rb:14

....[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:18:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:9

[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:81:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:72

.S.[Screenshot Image]: tmp/capybara/screenshots/failures_test_I_should_login_and_see_My_Profile.png 
E

Error:
LoginTest#test_I_should_login_and_see_My_Profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/login_test.rb:19:in `block in <class:LoginTest>'

bin/rails test test/system/sessions/login_test.rb:8

..S.[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:16:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4

.....

Finished in 646.574883s, 0.0495 runs/s, 0.1129 assertions/s.
32 runs, 73 assertions, 1 failures, 8 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [33m300ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m251ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m259ms[39m

```

Agent results:
- **backend**: Completed via Warp CLI: 1 file(s) changed
