### PR TITLE
[DRAFT] Fix #1095

### DIFF
--- a/test/integration/switch_locale_test.rb
+++ b/test/integration/switch_locale_test.rb
@@ -43,15 +43,16 @@ class SwitchLocaleTest < ActionDispatch::IntegrationTest
       I18n.with_locale(locale) do
         get static_home_path
 
-        # Verify default locale link exists (relaxed selector - could be in nav or footer)
-        assert_select "a[href='/']", minimum: 1
+        # Verify language selector links exist in footer navigation
+        # Default locale link (English) should point to root
+        assert_select "footer .language-nav a[href='/']", minimum: 1
 
-        # Verify non-default locale links exist with correct hrefs
+        # Verify non-default locale links exist with correct hrefs in footer
         locales_except_default = I18n.available_locales - [I18n.default_locale]
 
         locales_except_default.each do |l|
-          # Language links should have correct href, regardless of DOM location
-          assert_select "a[href='/#{l}']", minimum: 1
+          # Language links should be in footer .language-nav
+          assert_select "footer .language-nav a[href='/#{l}']", minimum: 1
         end
       end
     end

--- a/test/system/locales_test.rb
+++ b/test/system/locales_test.rb
@@ -5,24 +5,12 @@ class LocalesTest < ApplicationSystemTestCase
   test 'the language selector shows all available locales' do
     visit '/'
     
-    # Check if new language selector button exists (future implementation)
-    if has_selector?('button[aria-haspopup]', wait: 0)
-      # New language selector: test dropdown functionality
-      find('button[aria-haspopup]').click
-      
-      # Verify all language options are present in the dropdown
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'English'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Português'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Français'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Español'
-    else
-      # Current implementation: test footer links
-      within 'footer' do
-        assert_selector 'a', text: 'English'
-        assert_selector 'a', text: 'Português'
-        assert_selector 'a', text: 'Français'
-        assert_selector 'a', text: 'Español'
-      end
+    # New language selector: test footer navigation
+    within 'footer .language-nav' do
+      assert_selector 'a', text: 'English'
+      assert_selector 'a', text: 'Português'
+      assert_selector 'a', text: 'Français'
+      assert_selector 'a', text: 'Español'
     end
    end
 


### PR DESCRIPTION
Automated solution for issue #1095

**Status**: Tests failed

Test output:
```
Running 63 tests in parallel using 3 processes
Run options: --seed 10969

# Running:

...............................................................

Finished in 1.409724s, 44.6896 runs/s, 120.5910 assertions/s.
63 runs, 170 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 1.13 seconds
Running 32 tests in parallel using 3 processes
Run options: --seed 33647

# Running:

S..[Screenshot Image]: tmp/capybara/screenshots/failures_test_When_I_log_out_I_can_not_leave_a_review.png 
F

Failure:
LogoutTest#test_When_I_log_out_I_can_not_leave_a_review [test/system/sessions/logout_test.rb:44]:
expected "/searches/new" to equal "/"

bin/rails test test/system/sessions/logout_test.rb:14

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:81:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:72

[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:18:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:9

[Screenshot Image]: tmp/capybara/screenshots/failures_test_I_should_login_and_see_My_Profile.png 
E

Error:
LoginTest#test_I_should_login_and_see_My_Profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/login_test.rb:19:in `block in <class:LoginTest>'

bin/rails test test/system/sessions/login_test.rb:8

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/coffeeshops_test.rb:129:in `block in <class:CoffeeshopsTest>'

bin/rails test test/system/coffeeshops_test.rb:121

.......S...[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:17:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8

SS...[Screenshot Image]: tmp/capybara/screenshots/failures_test_sign_in_and_visit_user_profile.png 
E

Error:
UsersTest#test_sign_in_and_visit_user_profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/users_test.rb:43:in `block in <class:UsersTest>'

bin/rails test test/system/users_test.rb:32

S..[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:16:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4



Finished in 588.017717s, 0.0544 runs/s, 0.1326 assertions/s.
32 runs, 78 assertions, 1 failures, 7 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m256ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m259ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m257ms[39m

```

Agent results:
- **backend**: Completed via Warp CLI: 2 file(s) changed
