### PR TITLE
[DRAFT] Fix #1093

### DIFF
--- a/app/views/layouts/_language_selector.html.erb
+++ b/app/views/layouts/_language_selector.html.erb
@@ -1,0 +1,9 @@
+<button
+  class="fixed top-4 right-20 z-50 p-3 rounded-full shadow-lg transition-all hover:scale-110 flex items-center gap-2"
+  aria-label="Select language"
+  style="position: fixed; top: 1rem; right: 5rem; z-index: 50;"
+>
+  <i class="material-icons" style="font-size: 20px;">language</i>
+  <span style="font-size: 14px; font-weight: 500;"><%= I18n.locale.to_s.upcase %></span>
+  <i class="material-icons" style="font-size: 20px;">arrow_drop_down</i>
+</button>


### PR DESCRIPTION
Automated solution for issue #1093

**Status**: Tests failed

Test output:
```
Running 63 tests in parallel using 3 processes
Run options: --seed 32974

# Running:

...............................................................

Finished in 0.424490s, 148.4134 runs/s, 400.4806 assertions/s.
63 runs, 170 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 0.56 seconds
Running 32 tests in parallel using 3 processes
Run options: --seed 58177

# Running:

.....[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:81:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:72

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:18:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:9

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:17:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/coffeeshops_test.rb:129:in `block in <class:CoffeeshopsTest>'

bin/rails test test/system/coffeeshops_test.rb:121

.SS.S.S...S........[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ExpectationNotMet: expected to find css "[id^='favorite_']" at least 1 time but there were no matches
    test/system/simple_favorite_test.rb:22:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4



Finished in 130.587199s, 0.2450 runs/s, 0.6739 assertions/s.
32 runs, 88 assertions, 0 failures, 5 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m64ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m87ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m84ms[39m

```

Agent results:
- **backend**: Completed via Warp CLI: 1 file(s) changed
