### PR TITLE
[DRAFT] Fix #1095

### DIFF
--- a/test/integration/switch_locale_test.rb
+++ b/test/integration/switch_locale_test.rb
@@ -57,6 +57,53 @@ class SwitchLocaleTest < ActionDispatch::IntegrationTest
     end
   end
 
+  test 'language selector links have proper CSS classes' do
+    get static_home_path
+    
+    # All language links should have the base language-nav__link class
+    assert_select 'footer .language-nav a.language-nav__link', count: I18n.available_locales.size
+    
+    # The active locale link should have the active class
+    assert_select 'footer .language-nav a.language-nav__link--active', count: 1
+  end
+
+  test 'active language link is properly marked for each locale' do
+    # Test default locale (English)
+    get static_home_path
+    assert_select 'footer .language-nav a.language-nav__link--active', count: 1
+    assert_select 'footer .language-nav a.language-nav__link--active', text: 'English'
+    
+    # Test each non-default locale explicitly
+    locales_to_test = [
+      { locale: :es, name: 'Español' },
+      { locale: :fr, name: 'Français' },
+      { locale: :'pt-BR', name: 'Português (Brasil)' }
+    ]
+    
+    locales_to_test.each do |locale_info|
+      get static_home_path(locale: locale_info[:locale])
+      
+      # There should be exactly one active link
+      assert_select 'footer .language-nav a.language-nav__link--active', count: 1
+      
+      # The active link should have the correct text
+      assert_select 'footer .language-nav a.language-nav__link--active', text: locale_info[:name]
+    end
+  end
+
+  test 'language selector has proper ARIA labels' do
+    get static_home_path
+    
+    # Language navigation should have proper ARIA label
+    assert_select 'footer nav.language-nav[aria-label]'
+    
+    # Each language link should have an aria-label
+    I18n.available_locales.each do |locale|
+      locale_name = I18n.t('layouts.footer.language_name_of_locale', locale: locale)
+      assert_select "footer .language-nav a[aria-label='#{locale_name}']"
+    end
+  end
+
   test 'en is the default locale' do
     get static_home_path
 

--- a/test/system/locales_test.rb
+++ b/test/system/locales_test.rb
@@ -5,24 +5,32 @@ class LocalesTest < ApplicationSystemTestCase
   test 'the language selector shows all available locales' do
     visit '/'
     
-    # Check if new language selector button exists (future implementation)
-    if has_selector?('button[aria-haspopup]', wait: 0)
-      # New language selector: test dropdown functionality
-      find('button[aria-haspopup]').click
-      
-      # Verify all language options are present in the dropdown
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'English'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Português'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Français'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Español'
-    else
-      # Current implementation: test footer links
-      within 'footer' do
-        assert_selector 'a', text: 'English'
-        assert_selector 'a', text: 'Português'
-        assert_selector 'a', text: 'Français'
-        assert_selector 'a', text: 'Español'
-      end
+    # Current implementation: test footer language navigation links
+    within 'footer .language-nav' do
+      assert_selector 'a.language-nav__link', text: 'English'
+      assert_selector 'a.language-nav__link', text: 'Português'
+      assert_selector 'a.language-nav__link', text: 'Français'
+      assert_selector 'a.language-nav__link', text: 'Español'
+    end
+  end
+
+  test 'the language selector highlights the active locale' do
+    visit '/'
+    
+    # Verify English is active by default
+    within 'footer .language-nav' do
+      english_link = find('a.language-nav__link', text: 'English')
+      assert english_link[:class].include?('language-nav__link--active'), 
+             'English link should have active class'
+    end
+    
+    # Switch to French and verify it becomes active
+    visit '/fr'
+    
+    within 'footer .language-nav' do
+      french_link = find('a.language-nav__link', text: 'Français')
+      assert french_link[:class].include?('language-nav__link--active'),
+             'French link should have active class'
     end
    end
 


### PR DESCRIPTION
Automated solution for issue #1095

**Status**: Tests failed

Test output:
```
Running 66 tests in parallel using 3 processes
Run options: --seed 29122

# Running:

..................................................................

Finished in 0.422961s, 156.0428 runs/s, 437.3926 assertions/s.
66 runs, 185 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 0.57 seconds
Running 33 tests in parallel using 3 processes
Run options: --seed 9018

# Running:

SSS..S...[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:17:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8

.S....[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:16:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4

.....[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/coffeeshops_test.rb:129:in `block in <class:CoffeeshopsTest>'

bin/rails test test/system/coffeeshops_test.rb:121

.....[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:81:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:72

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:18:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:9

..

Finished in 127.185679s, 0.2595 runs/s, 0.6998 assertions/s.
33 runs, 89 assertions, 0 failures, 5 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m59ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m90ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m83ms[39m

```

Agent results:
- **backend**: Completed via Warp CLI: 2 file(s) changed
