### PR TITLE
[DRAFT] Fix #1093

### DIFF
--- a/app/views/layouts/_language_selector.html.erb
+++ b/app/views/layouts/_language_selector.html.erb
@@ -1,0 +1,40 @@
+<div class="language-selector fixed top-4 left-4 z-50" data-controller="dropdown">
+  <!-- Toggle Button -->
+  <button
+    data-action="click->dropdown#toggle"
+    data-dropdown-target="button"
+    class="flex items-center gap-1 px-3 py-2 rounded-lg shadow-lg transition-all hover:scale-105 bg-white dark:bg-slate-800"
+    aria-label="<%= t('language_selector.toggle_label') %>"
+    aria-expanded="false"
+    aria-controls="language-dropdown"
+  >
+    <i class="material-icons" style="font-size: 20px;">language</i>
+    <span class="font-medium text-sm uppercase"><%= I18n.locale %></span>
+    <i class="material-icons" style="font-size: 20px;">arrow_drop_down</i>
+  </button>
+
+  <!-- Dropdown Menu -->
+  <div
+    id="language-dropdown"
+    data-dropdown-target="menu"
+    class="hidden absolute top-full left-0 mt-2 bg-white dark:bg-slate-800 rounded-lg shadow-xl overflow-hidden min-w-[160px]"
+    role="menu"
+  >
+    <% I18n.available_locales.each do |locale| %>
+      <%= link_to request.params.merge(locale: resolve_locale(locale)),
+                  class: [
+                    'block px-4 py-3 transition-colors hover:bg-slate-100 dark:hover:bg-slate-700',
+                    ('bg-slate-100 dark:bg-slate-700 font-semibold' if locale == I18n.locale)
+                  ].compact.join(' '),
+                  role: 'menuitem',
+                  'aria-current': (locale == I18n.locale ? 'true' : nil) do %>
+        <span class="flex items-center gap-2">
+          <span class="font-medium text-sm uppercase"><%= locale %></span>
+          <span class="text-xs text-slate-600 dark:text-slate-400">
+            <%= t('.language_name', locale: locale, default: locale.to_s.upcase) %>
+          </span>
+        </span>
+      <% end %>
+    <% end %>
+  </div>
+</div>


### PR DESCRIPTION
Automated solution for issue #1093

**Status**: Tests failed

Test output:
```
Running 63 tests in parallel using 3 processes
Run options: --seed 60520

# Running:

...............................................................

Finished in 0.421486s, 149.4712 runs/s, 403.3349 assertions/s.
63 runs, 170 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 0.55 seconds
Running 32 tests in parallel using 3 processes
Run options: --seed 10446

# Running:

[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:81:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:72

E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:18:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:9

...S.S.SS......[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:17:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8

....[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/coffeeshops_test.rb:129:in `block in <class:CoffeeshopsTest>'

bin/rails test test/system/coffeeshops_test.rb:121

[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:16:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4

.S......

Finished in 127.038806s, 0.2519 runs/s, 0.6848 assertions/s.
32 runs, 87 assertions, 0 failures, 5 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m62ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m90ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m66ms[39m

```

Agent results:
- **backend**: Completed via Warp CLI: 1 file(s) changed
