### PR TITLE
[DRAFT] Fix #1095

### DIFF
--- a/test/integration/switch_locale_test.rb
+++ b/test/integration/switch_locale_test.rb
@@ -43,14 +43,13 @@ class SwitchLocaleTest < ActionDispatch::IntegrationTest
       I18n.with_locale(locale) do
         get static_home_path
 
-        # Verify default locale link exists (relaxed selector - could be in nav or footer)
+        # Verify language selector links exist with correct hrefs
+        # Default locale (en) uses '/' as href
         assert_select "a[href='/']", minimum: 1
 
-        # Verify non-default locale links exist with correct hrefs
+        # Non-default locales have explicit locale paths
         locales_except_default = I18n.available_locales - [I18n.default_locale]
-
         locales_except_default.each do |l|
-          # Language links should have correct href, regardless of DOM location
           assert_select "a[href='/#{l}']", minimum: 1
         end
       end

--- a/test/system/locales_test.rb
+++ b/test/system/locales_test.rb
@@ -5,26 +5,14 @@ class LocalesTest < ApplicationSystemTestCase
   test 'the language selector shows all available locales' do
     visit '/'
     
-    # Check if new language selector button exists (future implementation)
-    if has_selector?('button[aria-haspopup]', wait: 0)
-      # New language selector: test dropdown functionality
-      find('button[aria-haspopup]').click
-      
-      # Verify all language options are present in the dropdown
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'English'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Português'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Français'
-      assert_selector '[role="menu"] a, [role="menuitem"], .language-menu a', text: 'Español'
-    else
-      # Current implementation: test footer links
-      within 'footer' do
-        assert_selector 'a', text: 'English'
-        assert_selector 'a', text: 'Português'
-        assert_selector 'a', text: 'Français'
-        assert_selector 'a', text: 'Español'
-      end
+    # New language selector in footer - test that all language links are present
+    within 'footer .language-nav' do
+      assert_selector 'a.language-nav__link', text: 'English'
+      assert_selector 'a.language-nav__link', text: 'Português'
+      assert_selector 'a.language-nav__link', text: 'Français'
+      assert_selector 'a.language-nav__link', text: 'Español'
     end
-   end
+  end
 
 
   test 'en is the default locale' do


### PR DESCRIPTION
Automated solution for issue #1095

**Status**: Tests failed

Test output (local orchestrator run):
```
Running 63 tests in parallel using 3 processes
Run options: --seed 41192

# Running:

...............................................................

Finished in 0.420767s, 149.7266 runs/s, 404.0241 assertions/s.
63 runs, 170 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 0.53 seconds
Running 32 tests in parallel using 3 processes
Run options: --seed 47024

# Running:

SSSS...[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/coffeeshops_test.rb:129:in `block in <class:CoffeeshopsTest>'

bin/rails test test/system/coffeeshops_test.rb:121

[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_submit_a_review.png 
F

Failure:
CoffeeshopsTest#test_A_logged_in_user_can_submit_a_review [test/system/coffeeshops_test.rb:64]:
expected "/searches/3" to equal "/searches/2"

bin/rails test test/system/coffeeshops_test.rb:49

.....S[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:16:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4

............[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:17:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:81:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:72

[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:18:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:9



Finished in 124.012001s, 0.2580 runs/s, 0.6693 assertions/s.
32 runs, 83 assertions, 1 failures, 5 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m66ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m69ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m60ms[39m

```

Detected failing tests from local run (heuristic):
```txt
Error:
Failure:
Error:
Error:
Error:
Error:
```

New failing tests vs base (heuristic):
```txt
Error:
Failure:
```

Agent results:
- **backend**: Completed via Warp CLI: 2 file(s) changed
