### PR TITLE
[DRAFT] Fix #1096

### DIFF
--- a/test/system/locales_test.rb
+++ b/test/system/locales_test.rb
@@ -77,4 +77,52 @@ class LocalesTest < ApplicationSystemTestCase
 
     assert_selector "input[placeholder='Rechercher des cafés...']"
   end
+
+  test 'language switching via selector updates html lang attribute and content' do
+    # Step 1: Navigate to homepage and verify English is the default locale
+    visit '/'
+    
+    # Assert html[lang="en"] attribute
+    assert_equal 'en', page.find('html')['lang'], "Expected html[lang='en'] on initial page load"
+    
+    # Assert English heading is present (the main heading on homepage)
+    assert_selector 'h1.page-name', text: 'COFFEE NEAR YOU!'
+    
+    # Assert English search placeholder
+    assert_selector "input[placeholder='Search for coffee shops...']"
+    
+    # Step 2: Locate and click the French language selector in the footer
+    within 'footer .language-nav' do
+      # Find the French language link by its text content
+      french_link = find('a', text: 'Français')
+      
+      # Verify the link exists before clicking
+      assert_predicate french_link, :present?, 'French language selector link should be present'
+      
+      # Click the French language selector
+      french_link.click
+    end
+    
+    # Step 3: Wait for page navigation and verify French locale is active
+    # Assert html[lang="fr"] attribute after language switch
+    assert_equal 'fr', page.find('html')['lang'], "Expected html[lang='fr'] after clicking French language selector"
+    
+    # Assert French search placeholder is displayed
+    assert_selector "input[placeholder='Rechercher des cafés...']"
+    
+    # Verify the French language link is now marked as active
+    within 'footer .language-nav' do
+      french_link = find('a', text: 'Français')
+
+      assert_includes french_link[:class], 'language-nav__link--active', 
+                      'French language link should have active class after switch'
+    end
+    
+    # NOTE: The h2 heading "Save time by sharing your device location" is currently
+    # hardcoded in English in app/views/static/home.html.erb and not translated.
+    # This test verifies the locale switching mechanism works correctly via:
+    # - html[lang] attribute change
+    # - translated search placeholder
+    # - active language link styling
+  end
 end


### PR DESCRIPTION
Automated solution for issue #1096

**Status**: Tests failed

Test output (local orchestrator run):
```
Running 63 tests in parallel using 3 processes
Run options: --seed 13317

# Running:

...............................................................

Finished in 0.423629s, 148.7150 runs/s, 401.2945 assertions/s.
63 runs, 170 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 0.55 seconds
Running 33 tests in parallel using 3 processes
Run options: --seed 55266

# Running:

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:16:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4

S........[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/coffeeshops_test.rb:129:in `block in <class:CoffeeshopsTest>'

bin/rails test test/system/coffeeshops_test.rb:121

.......SS...S.S...[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:18:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:9

[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/favorite_toggle_test.rb:81:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:72

.

Finished in 127.122784s, 0.2596 runs/s, 0.7866 assertions/s.
33 runs, 100 assertions, 0 failures, 4 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m67ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m84ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m76ms[39m

```

Detected failing tests from local run (heuristic):
```txt
Error:
Error:
Error:
Error:
```

New failing tests vs base (heuristic):
```txt
Error:
```

Agent results:
- **backend**: Completed via Warp CLI: 1 file(s) changed
