### PR TITLE
[DRAFT] Fix #1151

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,4 +1,8 @@
 ENV['RAILS_ENV'] ||= 'test'
+ENV['HEADLESS'] ||= 'true'
+ENV['CUPRITE'] ||= 'true'
+ENV['APP_HOST'] ||= 'localhost'
+ENV['CUPRITE_JS_ERRORS'] ||= 'false'
 require 'minitest'
 require 'mocha/minitest'
 require_relative '../config/environment'
@@ -53,7 +57,7 @@ Capybara.javascript_driver = :ferrum_block_fonts
 
 class ActiveSupport::TestCase
   # Run tests in parallel with configurable workers (default: 3) even for small suites
-  parallelize(workers: ENV.fetch("RAILS_TEST_WORKERS", 3).to_i, threshold: 0)
+  parallelize(workers: ENV.fetch('RAILS_TEST_WORKERS', 3).to_i, threshold: 0)
 
   # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
   fixtures :all


### PR DESCRIPTION
Automated solution for issue #1151

**Status**: Tests failed

Test output (local orchestrator run):
```
Running 63 tests in parallel using 3 processes
Run options: --seed 23912

# Running:

...............................................................

Finished in 1.460703s, 43.1299 runs/s, 116.3823 assertions/s.
63 runs, 170 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 1.09 seconds
Running 32 tests in parallel using 3 processes
Run options: --seed 59659

# Running:

..[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
F

Failure:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons [test/system/favorite_toggle_test.rb:19]:
expected to find css "form.search-bar-container" but there were no matches

bin/rails test test/system/favorite_toggle_test.rb:9

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
F

Failure:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term [test/system/favorite_toggle_test.rb:84]:
expected to find css "form.search-bar-container" but there were no matches

bin/rails test test/system/favorite_toggle_test.rb:74

S[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:17:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4

S..SS..[Screenshot Image]: tmp/capybara/screenshots/failures_test_When_I_log_out_I_can_not_leave_a_review.png 
E

Error:
LogoutTest#test_When_I_log_out_I_can_not_leave_a_review:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/logout_test.rb:23:in `block in <class:LogoutTest>'

bin/rails test test/system/sessions/logout_test.rb:14

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:18:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8

....[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_submit_a_review.png 
F

Failure:
CoffeeshopsTest#test_A_logged_in_user_can_submit_a_review [test/system/coffeeshops_test.rb:66]:
expected "/searches/3" to equal "/searches/2"

bin/rails test test/system/coffeeshops_test.rb:49

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
F

Failure:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop [test/system/coffeeshops_test.rb:133]:
expected to find css "form.search-bar-container" but there were no matches

bin/rails test test/system/coffeeshops_test.rb:124

S...[Screenshot Image]: tmp/capybara/screenshots/failures_test_I_should_login_and_see_My_Profile.png 
E

Error:
LoginTest#test_I_should_login_and_see_My_Profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/login_test.rb:19:in `block in <class:LoginTest>'

bin/rails test test/system/sessions/login_test.rb:8

...

Finished in 457.766653s, 0.0699 runs/s, 0.1879 assertions/s.
32 runs, 86 assertions, 4 failures, 4 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [33m323ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m286ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m247ms[39m

```

Detected failing tests from local run (heuristic):
```txt
Failure:
Failure:
Error:
Error:
Error:
Failure:
Failure:
Error:
```

New failing tests vs base (heuristic):
```txt
Error:
Failure:
```

Agent results:
- **backend**: Completed via Warp CLI: 1 file(s) changed
