### PR TITLE
[DRAFT] Fix #1134

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,9 +52,6 @@ end
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 gem 'bcrypt', '~> 3.1.20'
 
-# Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
-
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -582,7 +582,6 @@ DEPENDENCIES
   sqlite3 (~> 2.8)
   tailwindcss-rails (~> 4.4)
   turbo-rails (~> 2.0)
-  tzinfo-data
   web-console
   webmock
   yaml-lint


### PR DESCRIPTION
Automated solution for issue #1134

**Status**: Tests failed

Test output (local orchestrator run):
```
Running 63 tests in parallel using 3 processes
Run options: --seed 37510

# Running:

...............................................................

Finished in 1.462694s, 43.0712 runs/s, 116.2239 assertions/s.
63 runs, 170 assertions, 0 failures, 0 errors, 0 skips

🐢  Precompiling assets.
Finished in 1.11 seconds
Running 32 tests in parallel using 3 processes
Run options: --seed 25192

# Running:

[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
F

Failure:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop [test/system/coffeeshops_test.rb:133]:
expected to find css "form.search-bar-container" but there were no matches

bin/rails test test/system/coffeeshops_test.rb:124

..S..S[Screenshot Image]: tmp/capybara/screenshots/failures_test_sign_in_and_visit_user_profile.png 
E

Error:
UsersTest#test_sign_in_and_visit_user_profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/users_test.rb:43:in `block in <class:UsersTest>'

bin/rails test test/system/users_test.rb:32

.S.........[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:18:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:17:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:4

..[Screenshot Image]: tmp/capybara/screenshots/failures_test_I_should_login_and_see_My_Profile.png 
E

Error:
LoginTest#test_I_should_login_and_see_My_Profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/login_test.rb:19:in `block in <class:LoginTest>'

bin/rails test test/system/sessions/login_test.rb:8

.S[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
F

Failure:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term [test/system/favorite_toggle_test.rb:84]:
expected to find css "form.search-bar-container" but there were no matches

bin/rails test test/system/favorite_toggle_test.rb:74

S[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
F

Failure:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons [test/system/favorite_toggle_test.rb:19]:
expected to find css "form.search-bar-container" but there were no matches

bin/rails test test/system/favorite_toggle_test.rb:9

..

Finished in 436.190052s, 0.0734 runs/s, 0.2178 assertions/s.
32 runs, 95 assertions, 3 failures, 4 errors, 5 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m265ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m277ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m257ms[39m

```

Detected failing tests from local run (heuristic):
```txt
Failure:
Error:
Error:
Error:
Error:
Failure:
Failure:
```

New failing tests vs base (heuristic):
```txt
Error:
Failure:
```

Agent results:
- **backend**: Completed via Warp CLI: 2 file(s) changed
