### PR TITLE
Phase 1: Remove language links from footer

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -11,39 +11,19 @@
         <li>
           <%= link_to "About", 
                       static_home_url,
-                      class: "language-nav__link" %>
+                      class: "footer-link" %>
         </li>
         <li>
           <%= link_to "Contact", 
                       static_home_url,
-                      class: "language-nav__link" %>
+                      class: "footer-link" %>
         </li>
         <li>
           <%= link_to "Privacy", 
                       static_home_url,
-                      class: "language-nav__link" %>
+                      class: "footer-link" %>
         </li>
       </ul>
-
-      <!-- Language Navigation -->
-      <nav class="language-nav" aria-label="Language and footer links">
-        <% I18n.available_locales.each_with_index do |locale, index| %>
-          <span class="language-nav__item">
-            <%= link_to request.params.merge(locale: resolve_locale(locale)),
-                        class: [
-                          'language-nav__link',
-                          ("language-nav__link--active" if locale == I18n.locale)
-                        ].compact.join(" "),
-                        "aria-label": t('.language_name_of_locale', locale:) do %>
-              <%= t('.language_name_of_locale', locale:) %>
-            <% end %>
-          </span>
-          <% if index < I18n.available_locales.size - 1 %>
-            <span class="language-nav__separator" aria-hidden="true">|</span>
-          <% end %>
-        <% end %>
-        <span class="language-nav__cta"><%= Flipper[:early_access_preview].enabled? ? t('.early-access') : t('.coming-soon-sig') %></span>
-      </nav>
     </div>
   </div>
 </footer>

--- a/test/integration/switch_locale_test.rb
+++ b/test/integration/switch_locale_test.rb
@@ -39,6 +39,8 @@ class SwitchLocaleTest < ActionDispatch::IntegrationTest
   end
 
   test 'Links to all available locales will show' do
+    skip "Language links removed from footer in Phase 1 - will be tested in Phase 2 when navbar selector is implemented"
+    
     [:en, :"pt-BR"].each do |locale|
       I18n.with_locale(locale) do
         get static_home_path

--- a/test/system/enabled_features_test.rb
+++ b/test/system/enabled_features_test.rb
@@ -20,6 +20,8 @@ class EnabledFeaturesTest < ApplicationSystemTestCase
   # enable the feature manually in .env.test.local
   # FLIPPER_EARLY_ACCESS_PREVIEW=true
   test 'I should see Early Access Preview' do
+    skip "Early Access Preview text removed from footer in Phase 1 - will be tested in Phase 2 when navbar selector is implemented"
+    
     Flipper.enable(:early_access_preview)
     visit '/'
 
@@ -27,6 +29,8 @@ class EnabledFeaturesTest < ApplicationSystemTestCase
   end
 
   test 'I should not see Early Access Preview' do
+    skip "Coming Soon text removed from footer in Phase 1 - will be tested in Phase 2 when navbar selector is implemented"
+    
     Flipper.disable(:early_access_preview)
     visit '/'
 

--- a/test/system/locales_test.rb
+++ b/test/system/locales_test.rb
@@ -3,6 +3,8 @@ require 'application_system_test_case'
 class LocalesTest < ApplicationSystemTestCase
 
   test 'the language selector shows all available locales' do
+    skip "Language links removed from footer in Phase 1 - will be tested in Phase 2 when navbar selector is implemented"
+    
     visit '/'
     
     # Check if new language selector button exists (future implementation)


### PR DESCRIPTION
Phase 1: Remove language links from footer

- Remove entire language navigation section from footer
- Keep About, Contact, Privacy links with updated CSS classes  
- Update tests to skip language functionality until Phase 2
- Prepare footer for navbar language selector in next phase

**Changes Made:**
- Removed language navigation section from `_footer.html.erb`
- Updated CSS classes from `language-nav__link` to `footer-link`
- Skipped language-related tests in locales, enabled_features, and switch_locale tests
- All existing functionality preserved except language links

**Testing Done:**
- All system tests pass (33 tests, 8 skips as expected)
- All unit tests pass (63 tests, 1 skip as expected)  
- Footer shows only About, Contact, Privacy links
- No language links or early access text visible

Completes Phase 1 of language selector implementation
Addresses #1173

**Next Phase:** Phase 2 will add language selector to navbar

Fixes #1173