### PR TITLE
[DRAFT] Fix #1137

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -5,24 +5,12 @@
       <p class="footer-text">
         © <%= Time.current.year %> Jitter
       </p>
-      
+
       <!-- Footer Links -->
       <ul class="flex items-center gap-6">
-        <li>
-          <%= link_to "About", 
-                      static_home_url,
-                      class: "footer-link" %>
-        </li>
-        <li>
-          <%= link_to "Contact", 
-                      static_home_url,
-                      class: "footer-link" %>
-        </li>
-        <li>
-          <%= link_to "Privacy", 
-                      static_home_url,
-                      class: "footer-link" %>
-        </li>
+        <li><%= link_to "About", static_home_url, class: "footer-link" %></li>
+        <li><%= link_to "Contact", static_home_url, class: "footer-link" %></li>
+        <li><%= link_to "Privacy", static_home_url, class: "footer-link" %></li>
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Automated solution for issue #1137

**Status**: Tests failed

Test output (local orchestrator run):
```

🐢  Precompiling assets.
Finished in 0.99 seconds
Running 96 tests in parallel using 3 processes
Run options: --seed 32167

# Running:

........S[Screenshot Image]: tmp/capybara/screenshots/failures_test_a_mobile_user_can_share_their_location-_search_for_tacos-_and_get_directions.png 
E

Error:
MobileUserJourneyTest#test_a_mobile_user_can_share_their_location,_search_for_tacos,_and_get_directions:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:56067/ reached server, but there are still pending connections: http://127.0.0.1:56067/, http://127.0.0.1:56067/assets/application-6a977ec6.js, https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js, http://127.0.0.1:56067/assets/turbo.min-ad2c7b86.js, http://127.0.0.1:56067/assets/stimulus.min-4b1e420e.js, http://127.0.0.1:56067/assets/stimulus-loading-1fc53fe7.js, https://ga.jspm.io/npm:@fortawesome/fontawesome-free@6.1.1/js/all.js, http://127.0.0.1:56067/assets/controllers/application-a7a6f248.js, http://127.0.0.1:56067/assets/controllers/geolocation_controller-6d3cfa37.js, http://127.0.0.1:56067/assets/controllers/hello_controller-dc142e8c.js, http://127.0.0.1:56067/assets/controllers/index-b474d080.js, http://127.0.0.1:56067/assets/controllers/theme_controller-1d449c68.js
    test/system/mobile_user_journey_test.rb:27:in `block in <class:MobileUserJourneyTest>'

bin/rails test test/system/mobile_user_journey_test.rb:26

....S...SS........E

Error:
ThemeToggleTest#test_user_can_toggle_between_light_and_dark_mode:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    test/system/theme_toggle_test.rb:9:in `block in <class:ThemeToggleTest>'

Error:
ThemeToggleTest#test_user_can_toggle_between_light_and_dark_mode:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/theme_toggle_test.rb:4

..........E

Error:
LocalesTest#test_en_is_the_default_locale:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    test/system/locales_test.rb:33:in `block in <class:LocalesTest>'

Error:
LocalesTest#test_en_is_the_default_locale:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/locales_test.rb:32

E

Error:
LocalesTest#test_navigation_will_update_the_locale:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    test/system/locales_test.rb:42:in `block in <class:LocalesTest>'

Error:
LocalesTest#test_navigation_will_update_the_locale:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/locales_test.rb:41

S[Screenshot Image]: tmp/capybara/screenshots/failures_test_I_should_login_and_see_My_Profile.png 
E

Error:
LoginTest#test_I_should_login_and_see_My_Profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/login_test.rb:19:in `block in <class:LoginTest>'

bin/rails test test/system/sessions/login_test.rb:8

.E

Error:
LogoutTest#test_When_I_log_out_I_can_not_leave_a_review:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:56067/login reached server, but there are still pending connections: https://fonts.gstatic.com/s/nunito/v32/XRXV3I6Li01BKofINeaBTMnFcQ.woff2, https://fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2
    test/system/sessions/logout_test.rb:15:in `block in <class:LogoutTest>'

Error:
LogoutTest#test_When_I_log_out_I_can_not_leave_a_review:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:209:in `cyclic?'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:196:in `reduce_props'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:163:in `handle_response'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:125:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/sessions/logout_test.rb:14

...E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:56067/login reached server, but there are still pending connections: https://fonts.gstatic.com/s/nunito/v32/XRXV3I6Li01BKofINeaBTMnFcQ.woff2, https://fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2
    test/system/debug_favorite_test.rb:10:in `block in <class:DebugFavoriteTest>'

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:209:in `cyclic?'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:196:in `reduce_props'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:163:in `handle_response'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:125:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/debug_favorite_test.rb:8

E

Error:
TailwindCssDeliveryTest#test_Tailwind_CSS_classes_are_present_without_CDN:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:56067/ reached server, but there are still pending connections: https://fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2
    test/system/tailwind_css_delivery_test.rb:5:in `block in <class:TailwindCssDeliveryTest>'

Error:
TailwindCssDeliveryTest#test_Tailwind_CSS_classes_are_present_without_CDN:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:209:in `cyclic?'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:196:in `reduce_props'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:163:in `handle_response'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:125:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/tailwind_css_delivery_test.rb:4

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:21:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:8

.E

Error:
CoffeeshopsTest#test_An_unauthenticated_user_can_view_coffeeshop_details:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    test/system/coffeeshops_test.rb:14:in `block in <class:CoffeeshopsTest>'

Error:
CoffeeshopsTest#test_An_unauthenticated_user_can_view_coffeeshop_details:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/coffeeshops_test.rb:13

E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_submit_a_review:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    test/system/coffeeshops_test.rb:52:in `block in <class:CoffeeshopsTest>'

Error:
CoffeeshopsTest#test_A_logged_in_user_can_submit_a_review:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/coffeeshops_test.rb:50

.......................E

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:56067/login reached server, but there are still pending connections: https://fonts.gstatic.com/s/nunito/v32/XRXV3I6Li01BKofINeaBTMnFcQ.woff2, https://fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2
    test/system/coffeeshops_test.rb:126:in `block in <class:CoffeeshopsTest>'

Error:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:209:in `cyclic?'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:196:in `reduce_props'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:163:in `handle_response'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:125:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/coffeeshops_test.rb:125

S[Screenshot Image]: tmp/capybara/screenshots/failures_test_manual_sign_in.png 
E

Error:
UsersTest#test_manual_sign_in:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    test/system/users_test.rb:24:in `block in <class:UsersTest>'

bin/rails test test/system/users_test.rb:23

E

Error:
UsersTest#test_sign_in_and_visit_user_profile:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    test/system/users_test.rb:34:in `block in <class:UsersTest>'

Error:
UsersTest#test_sign_in_and_visit_user_profile:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/users_test.rb:32

SSS[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_edit_and_delete_their_review.png 
F

Failure:
CoffeeshopsTest#test_A_logged_in_user_can_edit_and_delete_their_review [test/system/coffeeshops_test.rb:105]:
expected to find css "form" within #<Capybara::Node::Element tag="div" path="//HTML[1]/BODY[1]/DIV[3]/DIV[1]/DIV[3]/DIV[1]/DIV[1]"> but there were no matches

bin/rails test test/system/coffeeshops_test.rb:86

E

Error:
NavigationTest#test_A_user_can_search_and_return_using_the_back_button:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:56067/searches/new reached server, but there are still pending connections: https://fonts.gstatic.com/s/nunito/v32/XRXV3I6Li01BKofINeaBTMnFcQ.woff2, https://fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2
    test/system/navigation_test.rb:10:in `block in <class:NavigationTest>'

Error:
NavigationTest#test_A_user_can_search_and_return_using_the_back_button:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/navigation_test.rb:8

E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:56067/login reached server, but there are still pending connections: https://fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2
    test/system/favorite_toggle_test.rb:77:in `block in <class:FavoriteToggleTest>'

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:199:in `reduce_props'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:163:in `handle_response'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:125:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/favorite_toggle_test.rb:75

.....E

Error:
DisabledFeaturesTest#test_I_should_not_see_Early_Access_Preview:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:56067/ reached server, but there are still pending connections: https://fonts.gstatic.com/s/nunito/v32/XRXV3I6Li01BKofINeaBTMnFcQ.woff2, https://fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2
    test/system/disabled_features_test.rb:10:in `block in <class:DisabledFeaturesTest>'

Error:
DisabledFeaturesTest#test_I_should_not_see_Early_Access_Preview:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.1/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/disabled_features_test.rb:9

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
F

Failure:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons [test/system/favorite_toggle_test.rb:20]:
expected to find css "form.search-bar-container" but there were no matches

bin/rails test test/system/favorite_toggle_test.rb:10



Finished in 271.671102s, 0.3534 runs/s, 0.7251 assertions/s.
96 runs, 197 assertions, 2 failures, 17 errors, 9 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [33m304ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m255ms[39m

```

Detected failing tests from local run (heuristic):
```txt
Error:
MobileUserJourneyTest#test_a_mobile_user_can_share_their_location,_search_for_tacos,_and_get_directions:
Error:
ThemeToggleTest#test_user_can_toggle_between_light_and_dark_mode:
Error:
ThemeToggleTest#test_user_can_toggle_between_light_and_dark_mode:
Error:
LocalesTest#test_en_is_the_default_locale:
Error:
LocalesTest#test_en_is_the_default_locale:
```

New failing tests vs base (heuristic):
```txt
Error:
LocalesTest#test_en_is_the_default_locale:
LocalesTest#test_navigation_will_update_the_locale:
LoginTest#test_I_should_login_and_see_My_Profile:
LogoutTest#test_When_I_log_out_I_can_not_leave_a_review:
MobileUserJourneyTest#test_a_mobile_user_can_share_their_location,_search_for_tacos,_and_get_directions:
ThemeToggleTest#test_user_can_toggle_between_light_and_dark_mode:
```

Agent results:
- **backend**: Completed via Codex CLI: 1 file(s) changed
