### PR TITLE
[DRAFT] Fix #1165

### DIFF
--- a/test/support/system_test_helpers.rb
+++ b/test/support/system_test_helpers.rb
@@ -27,4 +27,33 @@ module SystemTestHelpers
   def silent_wait(seconds = 1)
     sleep seconds
   end
+
+  # Resize the current Capybara window to a mobile-friendly viewport
+  def resize_window_to_mobile(width: 375, height: 667)
+    resized = false
+
+    if page.respond_to?(:current_window) && page.current_window.respond_to?(:resize_to)
+      page.current_window.resize_to(width, height)
+      resized = true
+    elsif page.driver.respond_to?(:resize)
+      page.driver.resize(width, height)
+      resized = true
+    elsif page.driver.respond_to?(:resize_window_to)
+      page.driver.resize_window_to(page.driver.current_window_handle, width, height)
+      resized = true
+    elsif page.driver.respond_to?(:browser)
+      browser = page.driver.browser
+      if browser.respond_to?(:resize)
+        browser.resize(width, height)
+        resized = true
+      elsif browser.respond_to?(:manage) && browser.manage.respond_to?(:window)
+        browser.manage.window.resize_to(width, height)
+        resized = true
+      end
+    end
+
+    raise 'Current Capybara driver does not support window resizing' unless resized
+
+    page.evaluate_script('window.dispatchEvent(new Event("resize"))')
+  end
 end

--- a/test/system/mobile_view_test.rb
+++ b/test/system/mobile_view_test.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'application_system_test_case'
+
+class MobileViewTest < ApplicationSystemTestCase
+  setup do
+    resize_window_to_mobile
+  end
+
+  test 'navigation renders the mobile layout at small viewports' do
+    visit static_home_path
+
+    mobile_width = page.evaluate_script('window.innerWidth')
+    assert_operator mobile_width, :<=, 430, "Expected window width to be mobile-sized, got #{mobile_width}"
+
+    # Desktop nav should be hidden on mobile widths
+    desktop_nav_display = page.evaluate_script(<<~JS)
+      (() => {
+        const nav = document.querySelector('#nav-mobile');
+        return nav ? getComputedStyle(nav).display : null;
+      })();
+    JS
+    assert_equal 'none', desktop_nav_display
+
+    # Mobile menu trigger should be visible for mobile navigation
+    assert_selector '.sidenav-trigger', visible: true
+  end
+end


### PR DESCRIPTION
Automated solution for issue #1165

**Status**: Tests failed

Test output (local orchestrator run):
```

🐢  Precompiling assets.
Finished in 1.01 seconds
Running 97 tests in parallel using 3 processes
Run options: --seed 24230

# Running:

..........[Screenshot Image]: tmp/capybara/screenshots/failures_test_I_should_login_and_see_My_Profile.png 
E

Error:
LoginTest#test_I_should_login_and_see_My_Profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/login_test.rb:19:in `block in <class:LoginTest>'

bin/rails test test/system/sessions/login_test.rb:8

........[Screenshot Image]: tmp/capybara/screenshots/failures_test_can_click_favorite_button_and_see_it_on_profile_favorites.png 
E

Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/simple_favorite_test.rb:21:in `block in <class:SimpleFavoriteTest>'

bin/rails test test/system/simple_favorite_test.rb:8

[Screenshot Image]: tmp/capybara/screenshots/failures_test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop.png 
F

Failure:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop [test/system/coffeeshops_test.rb:134]:
expected to find css "form.search-bar-container" but there were no matches

bin/rails test test/system/coffeeshops_test.rb:125

.......S........[Screenshot Image]: tmp/capybara/screenshots/failures_test_When_I_log_out_I_can_not_leave_a_review.png 
E

Error:
LogoutTest#test_When_I_log_out_I_can_not_leave_a_review:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/sessions/logout_test.rb:23:in `block in <class:LogoutTest>'

bin/rails test test/system/sessions/logout_test.rb:14

SSS.S.[Screenshot Image]: tmp/capybara/screenshots/failures_test_sign_in_and_visit_user_profile.png 
E

Error:
UsersTest#test_sign_in_and_visit_user_profile:
Capybara::ElementNotFound: Unable to find css ".sidenav-trigger"
    test/system/users_test.rb:43:in `block in <class:UsersTest>'

bin/rails test test/system/users_test.rb:32

...........S..S......[Screenshot Image]: tmp/capybara/screenshots/failures_test_search_placeholder_is_correctly_translated.png 
E

Error:
LocalesTest#test_search_placeholder_is_correctly_translated:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:55533/ reached server, but there are still pending connections: https://fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2
    test/system/locales_test.rb:63:in `block in <class:LocalesTest>'

bin/rails test test/system/locales_test.rb:61

[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
E

Error:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:55527/login reached server, but there are still pending connections: https://fonts.gstatic.com/s/nunito/v32/XRXV3I6Li01BKofINeaBTMnFcQ.woff2
    test/system/favorite_toggle_test.rb:77:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:75

......E

Error:
CoffeeshopsControllerTest#test_should_get_show:
ActiveRecord::RecordNotFound: Couldn't find Coffeeshop with [WHERE "coffeeshops"."id" = ?]
    test/controllers/coffeeshops_controller_test.rb:5:in `setup'

bin/rails test test/controllers/coffeeshops_controller_test.rb:8

.SS[Screenshot Image]: tmp/capybara/screenshots/failures_test_logged_in_user_can_toggle_favorite_with_contextual_icons.png 
E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Ferrum::PendingConnectionsError: Request to http://127.0.0.1:55527/login reached server, but there are still pending connections: https://fonts.gstatic.com/s/nunito/v32/XRXV3I6Li01BKofINeaBTMnFcQ.woff2, https://fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2
    test/system/favorite_toggle_test.rb:12:in `block in <class:FavoriteToggleTest>'

bin/rails test test/system/favorite_toggle_test.rb:10

..[Screenshot Image]: tmp/capybara/screenshots/failures_test_a_mobile_user_can_share_their_location-_search_for_tacos-_and_get_directions.png 
F

Failure:
MobileUserJourneyTest#test_a_mobile_user_can_share_their_location,_search_for_tacos,_and_get_directions [test/system/mobile_user_journey_test.rb:33]:
expected to find css ".coffeeshop-card" but there were no matches

bin/rails test test/system/mobile_user_journey_test.rb:26

...E

Error:
CoffeeshopTest#test_coffeeshop_rating_must_be_between_1_and_5:
ActiveRecord::RecordNotFound: Couldn't find Coffeeshop with [WHERE "coffeeshops"."id" = ?]
    test/models/coffeeshop_test.rb:8:in `block in <class:CoffeeshopTest>'

bin/rails test test/models/coffeeshop_test.rb:15

E

Error:
CoffeeshopTest#test_coffeeshop_attributes_must_not_be_empty:
ActiveRecord::RecordNotFound: Couldn't find Coffeeshop with [WHERE "coffeeshops"."id" = ?]
    test/models/coffeeshop_test.rb:8:in `block in <class:CoffeeshopTest>'

bin/rails test test/models/coffeeshop_test.rb:10

...E

Error:
ReviewsControllerTest#test_should_destroy_the_user_review:
ActiveRecord::RecordNotFound: Couldn't find Coffeeshop with [WHERE "coffeeshops"."id" = ?]
    test/controllers/reviews_controller_test.rb:7:in `block in <class:ReviewsControllerTest>'

Error:
ReviewsControllerTest#test_should_destroy_the_user_review:
TypeError: wrong argument type NilClass (expected Proc/Method/UnboundMethod)
    test/controllers/reviews_controller_test.rb:24:in `define_singleton_method'
    test/controllers/reviews_controller_test.rb:24:in `block in <class:ReviewsControllerTest>'

bin/rails test test/controllers/reviews_controller_test.rb:100

E

Error:
ReviewsControllerTest#test_returns_turbo_stream_with_form_on_failure_for_turbo_clients:
ActiveRecord::RecordNotFound: Couldn't find Coffeeshop with [WHERE "coffeeshops"."id" = ?]
    test/controllers/reviews_controller_test.rb:7:in `block in <class:ReviewsControllerTest>'

Error:
ReviewsControllerTest#test_returns_turbo_stream_with_form_on_failure_for_turbo_clients:
TypeError: wrong argument type NilClass (expected Proc/Method/UnboundMethod)
    test/controllers/reviews_controller_test.rb:24:in `define_singleton_method'
    test/controllers/reviews_controller_test.rb:24:in `block in <class:ReviewsControllerTest>'

bin/rails test test/controllers/reviews_controller_test.rb:77

E

Error:
ReviewsControllerTest#test_updates_review_and_redirects_on_html_success:
ActiveRecord::RecordNotFound: Couldn't find Coffeeshop with [WHERE "coffeeshops"."id" = ?]
    test/controllers/reviews_controller_test.rb:7:in `block in <class:ReviewsControllerTest>'

Error:
ReviewsControllerTest#test_updates_review_and_redirects_on_html_success:
TypeError: wrong argument type NilClass (expected Proc/Method/UnboundMethod)
    test/controllers/reviews_controller_test.rb:24:in `define_singleton_method'
    test/controllers/reviews_controller_test.rb:24:in `block in <class:ReviewsControllerTest>'

bin/rails test test/controllers/reviews_controller_test.rb:46

E

Error:
ReviewsControllerTest#test_renders_edit_with_errors_on_html_failure:
ActiveRecord::RecordNotFound: Couldn't find Coffeeshop with [WHERE "coffeeshops"."id" = ?]
    test/controllers/reviews_controller_test.rb:7:in `block in <class:ReviewsControllerTest>'

Error:
ReviewsControllerTest#test_renders_edit_with_errors_on_html_failure:
TypeError: wrong argument type NilClass (expected Proc/Method/UnboundMethod)
    test/controllers/reviews_controller_test.rb:24:in `define_singleton_method'
    test/controllers/reviews_controller_test.rb:24:in `block in <class:ReviewsControllerTest>'

bin/rails test test/controllers/reviews_controller_test.rb:61

E

Error:
ReviewsControllerTest#test_should_create_review:
ActiveRecord::RecordNotFound: Couldn't find Coffeeshop with [WHERE "coffeeshops"."id" = ?]
    test/controllers/reviews_controller_test.rb:7:in `block in <class:ReviewsControllerTest>'

Error:
ReviewsControllerTest#test_should_create_review:
TypeError: wrong argument type NilClass (expected Proc/Method/UnboundMethod)
    test/controllers/reviews_controller_test.rb:24:in `define_singleton_method'
    test/controllers/reviews_controller_test.rb:24:in `block in <class:ReviewsControllerTest>'

bin/rails test test/controllers/reviews_controller_test.rb:31

.[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:18:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:8



Finished in 524.994802s, 0.1848 runs/s, 0.3943 assertions/s.
97 runs, 207 assertions, 2 failures, 16 errors, 9 skips

You have skipped tests. Run with --verbose for details.

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m247ms[39m
[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m212ms[39m

```

Detected failing tests from local run (heuristic):
```txt
Error:
LoginTest#test_I_should_login_and_see_My_Profile:
Error:
SimpleFavoriteTest#test_can_click_favorite_button_and_see_it_on_profile_favorites:
Failure:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop [test/system/coffeeshops_test.rb:134]:
Error:
LogoutTest#test_When_I_log_out_I_can_not_leave_a_review:
Error:
UsersTest#test_sign_in_and_visit_user_profile:
```

New failing tests vs base (heuristic):
```txt
CoffeeshopsControllerTest#test_should_get_show:
CoffeeshopsTest#test_A_logged_in_user_can_favorite_and_unfavorite_a_coffeeshop [test/system/coffeeshops_test.rb:134]:
Error:
Failure:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
LocalesTest#test_search_placeholder_is_correctly_translated:
LoginTest#test_I_should_login_and_see_My_Profile:
LogoutTest#test_When_I_log_out_I_can_not_leave_a_review:
MobileUserJourneyTest#test_a_mobile_user_can_share_their_location,_search_for_tacos,_and_get_directions [test/system/mobile_user_journey_test.rb:33]:
```

Agent results:
- **backend**: Completed via Codex CLI: 13 file(s) changed
- **frontend**: Completed via Codex CLI: 2 file(s) changed
