### PR TITLE
Align Yelp API stubs with search terms in system tests

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -22,7 +22,7 @@ EvilSystems.initial_setup
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
   setup do
     ENV['YELP_API_KEY'] = 'test-key'
-    stub_yelp_api_request
+    stub_yelp_api_request('coffee')
   end
 
   teardown do

--- a/test/system/coffeeshops_test.rb
+++ b/test/system/coffeeshops_test.rb
@@ -4,7 +4,7 @@ class CoffeeshopsTest < ApplicationSystemTestCase
   include ActionView::Helpers::NumberHelper
 
   setup do
-    stub_yelp_api_request
+    stub_yelp_api_request('coffee')
     @user = users(:two)
     @coffeeshop = coffeeshops(:two)
     @review = reviews(:two)

--- a/test/system/navigation_test.rb
+++ b/test/system/navigation_test.rb
@@ -2,7 +2,7 @@ require 'application_system_test_case'
 
 class NavigationTest < ApplicationSystemTestCase
   setup do
-    stub_yelp_api_request
+    stub_yelp_api_request('tacos')
   end
 
   test 'A user can search and return using the back button' do

--- a/test/system/searches_test.rb
+++ b/test/system/searches_test.rb
@@ -5,7 +5,7 @@ class SearchesTest < ApplicationSystemTestCase
     'div[role="main"], main, [data-controller~="search"]'.freeze
 
   setup do
-    stub_yelp_api_request
+    stub_yelp_api_request('yoga')
   end
 
   test 'An anonymous user at the static home can search by query and view results' do
@@ -56,7 +56,9 @@ class SearchesTest < ApplicationSystemTestCase
     skip 'Focused on interactive query UX; run locally, skipped in CI for stability' if ENV['CI'] == 'true'
     query = 'yoga'
     query2 = 'coffee'
-    
+
+    stub_yelp_api_request(query)
+
     # Visit the home page and wait for it to load
     visit '/'
     
@@ -90,6 +92,8 @@ class SearchesTest < ApplicationSystemTestCase
     assert_selector 'form[action="/searches"]', wait: 10
     search_box = find(:fillable_field, 'search[query]', wait: 10)
     search_box.fill_in(with: query2)
+
+    stub_yelp_api_request(query2)
 
     # Verify the search query was updated
     assert_selector(:fillable_field, 'search[query]', with: query2, wait: 5)

--- a/test/system/simple_favorite_test.rb
+++ b/test/system/simple_favorite_test.rb
@@ -2,7 +2,7 @@ require 'application_system_test_case'
 
 class SimpleFavoriteTest < ApplicationSystemTestCase
   setup do
-    stub_yelp_api_request
+    stub_yelp_api_request('coffee')
   end
 
   test 'can click favorite button and see it on profile favorites' do


### PR DESCRIPTION
## Summary
- pass explicit search terms to Yelp API stubs in system tests to align mock data with each scenario
- refresh multi-query search test stubs when switching search terms and default the base system test stub to coffee
- ensure navigation, favorite, and coffeeshop flows request the appropriate Yelp stub responses

## Testing
- HEADLESS=true bundle exec rails test test/system/searches_test.rb test/system/navigation_test.rb test/system/simple_favorite_test.rb test/system/coffeeshops_test.rb *(fails: `bundle`/`ruby` not available in container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f3662173083218e333dd0590efa4a)