### PR TITLE
Streamline Dependabot CI fast path

### DIFF
--- a/.github/workflows/auto-approve.yml
+++ b/.github/workflows/auto-approve.yml
@@ -7,7 +7,8 @@ on:
   # Fallback triggers for direct Dependabot PR events
   pull_request:
     types: [opened, synchronize, reopened]
-    if: github.actor == 'dependabot[bot]'
+  pull_request_target:
+    types: [opened, synchronize, reopened]
 
 permissions:
   pull-requests: write
@@ -21,8 +22,20 @@ jobs:
     runs-on: ubuntu-latest
     # Handle both workflow_run and direct pull_request triggers
     if: |
-      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.actor.login == 'dependabot[bot]') ||
-      (github.event_name == 'pull_request' && github.actor == 'dependabot[bot]')
+      (
+        github.event_name == 'workflow_run' &&
+        github.event.workflow_run.conclusion == 'success' &&
+        (
+          github.event.workflow_run.actor.login == 'dependabot[bot]' ||
+          startsWith(github.event.workflow_run.head_branch, 'dependabot/')
+        )
+      ) ||
+      (
+        github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
+      ) ||
+      (
+        github.event_name == 'pull_request_target' && github.actor == 'dependabot[bot]'
+      )
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -40,6 +53,14 @@ jobs:
             echo "Found PR number from pull_request: $PR_NUMBER"
           fi
           echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+
+      - name: Fetch Dependabot metadata
+        if: steps.pr.outputs.number != ''
+        id: metadata
+        uses: dependabot/fetch-metadata@v2.4.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          pull-request: ${{ steps.pr.outputs.number || github.event.pull_request.number || '' }}
 
       - name: Update PR with latest develop changes if needed
         if: steps.pr.outputs.number != ''
@@ -59,7 +80,7 @@ jobs:
           fi
 
       - name: Approve and enable auto-merge for Dependabot PR
-        if: steps.pr.outputs.number != ''
+        if: steps.pr.outputs.number != '' && steps.metadata.outputs.update-type != 'version-update:semver-major'
         env:
           PR_NUMBER: ${{ steps.pr.outputs.number }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -71,3 +92,12 @@ jobs:
 
           # Enable GitHub auto-merge (squash). It will merge automatically once all required checks pass and branch protection is satisfied.
           gh pr merge --auto --squash "$PR_NUMBER"
+
+      - name: Flag major updates for manual review
+        if: steps.pr.outputs.number != '' && steps.metadata.outputs.update-type == 'version-update:semver-major'
+        env:
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Major update detected for PR #$PR_NUMBER - leaving for manual review"
+          gh pr comment "$PR_NUMBER" --body "⚠️ Major version bump detected. CI approval has been applied, but auto-merge is disabled so a human can review and merge."

--- a/.github/workflows/dependabot-risk-assessment.yml
+++ b/.github/workflows/dependabot-risk-assessment.yml
@@ -10,7 +10,10 @@ permissions:
 
 jobs:
   assess-risk:
-    if: github.actor == 'dependabot[bot]'
+    # Run for Dependabot PRs even when the triggering actor is a merge bot or human
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]') ||
+      startsWith(github.head_ref || github.ref_name, 'dependabot/')
     runs-on: ubuntu-latest
     outputs:
       risk-level: ${{ steps.assessment.outputs.risk-level }}
@@ -36,7 +39,8 @@ jobs:
           
           # Initialize variables
           RISK_LEVEL="medium"
-          SKIP_SYSTEM_TESTS="false"
+          # Default to skipping system tests unless this is a major bump
+          SKIP_SYSTEM_TESTS="true"
           UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"
           DEPENDENCY_TYPE="${{ steps.metadata.outputs.dependency-type }}"
           
@@ -47,36 +51,21 @@ jobs:
           
           echo "Evaluating risk level..."
           
-          # Low risk criteria for patch updates
-          if [[ "$UPDATE_TYPE" == "version-update:semver-patch" ]]; then
-            echo "Patch update detected"
-            
-            # Check if it's a development/test dependency
-            if [[ "$DEPENDENCY_TYPE" == "development" || "$DEPENDENCY_TYPE" == "test" ]]; then
-              echo "Development/test dependency - low risk"
-              RISK_LEVEL="low"
-              SKIP_SYSTEM_TESTS="true"
-            else
-              # For runtime dependencies, be more conservative with patches
-              echo "Runtime dependency - medium risk for patch"
-              RISK_LEVEL="medium"
-              SKIP_SYSTEM_TESTS="false"
-            fi
-          elif [[ "$UPDATE_TYPE" == "version-update:semver-minor" ]]; then
-            echo "Minor update detected - medium risk"
-            RISK_LEVEL="medium"
-            SKIP_SYSTEM_TESTS="false"
-          elif [[ "$UPDATE_TYPE" == "version-update:semver-major" ]]; then
-            echo "Major update detected - high risk"
+          # Only run system tests for major version bumps
+          if [[ "$UPDATE_TYPE" == "version-update:semver-major" ]]; then
+            echo "Major update detected - high risk, keep system tests enabled"
             RISK_LEVEL="high"
             SKIP_SYSTEM_TESTS="false"
+          else
+            echo "Non-major update detected - skip system tests and rely on unit suites"
+            RISK_LEVEL="low"
+            SKIP_SYSTEM_TESTS="true"
           fi
           
-          # Override for security updates (always high risk)
+          # Security updates remain high risk but still follow the fast-path testing strategy
           if [[ "$ALERT_STATE" == "OPEN" ]]; then
-            echo "Security update detected - high risk"
+            echo "Security update detected - keep fast path but mark as high risk"
             RISK_LEVEL="high"
-            SKIP_SYSTEM_TESTS="false"
           fi
           
           # Set outputs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,10 @@ permissions:
 jobs:
   # Get risk assessment for Dependabot PRs (optional job)
   get-risk-assessment:
-    if: github.actor == 'dependabot[bot]'
+    # Run for Dependabot PRs even when the triggering actor is a merge bot or human
+    if: |
+      (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'dependabot[bot]') ||
+      startsWith(github.head_ref || github.ref_name, 'dependabot/')
     runs-on: ubuntu-latest
     outputs:
       skip-system-tests: ${{ steps.assessment.outputs.skip-system-tests }}
@@ -55,11 +58,15 @@ jobs:
           # Same logic as in risk assessment workflow
           UPDATE_TYPE="${{ steps.metadata.outputs.update-type }}"
           DEPENDENCY_TYPE="${{ steps.metadata.outputs.dependency-type }}"
-          SKIP_SYSTEM_TESTS="false"
+          # Default to skipping system tests unless this is a major bump
+          SKIP_SYSTEM_TESTS="true"
           RISK_LEVEL="medium"
-          
-          if [[ "$UPDATE_TYPE" == "version-update:semver-patch" ]] && [[ "$DEPENDENCY_TYPE" == "development" || "$DEPENDENCY_TYPE" == "test" ]]; then
-            SKIP_SYSTEM_TESTS="true"
+
+          if [[ "$UPDATE_TYPE" == "version-update:semver-major" ]]; then
+            SKIP_SYSTEM_TESTS="false"
+            RISK_LEVEL="high"
+          else
+            # Patch/minor/security updates rely on the faster unit suites
             RISK_LEVEL="low"
           fi
           


### PR DESCRIPTION
## Summary
- ensure Dependabot risk-assessment runs even when merge bots update the branch
- run system tests only for major Dependabot updates while keeping unit suites for everything else
- auto-approve workflow skips auto-merge on major bumps and leaves a note for manual review

## Testing
- not run (CI-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f4ec9e1348321acb57cb3b0ba43cc)