### PR TITLE
Ensure mise trusts config and uses core Ruby plugin

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -5,6 +5,9 @@
 # please remove flaky backends and tools from here
 # ALWAYS USE MISE TO MANAGE THIS FILE (ie mise list, mise install, mise remove)
 
+[plugins]
+ruby = "core"
+
 [tools]
 ruby = "3.3.10"
 # lefthook is installed via Homebrew
@@ -28,6 +31,7 @@ experimental = true
 legacy_version_file = true # Changed as per PR 3 Option A
 # Enable faster installation via precompiled binaries
 always_keep_download = true
+trusted_config_paths = ["."]
 
 [tasks.setup]
 description = "Run development setup script"


### PR DESCRIPTION
## Summary
- declare the Ruby plugin as mise core so the toolchain avoids asdf defaults
- mark the repository path as a trusted config location to suppress trust prompts in managed environments

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f57a56db08321b871cb74c7ac305c)