### PR TITLE
docs: Replace web browsing requirement with mise-based verification workflow

### DIFF
--- a/.github/prompts/headless-visual-verification.prompt.md
+++ b/.github/prompts/headless-visual-verification.prompt.md
@@ -11,9 +11,10 @@ Scope
 
 You MUST:
 - Treat any non-trivial visual/UI change (layout, CSS, DOM structure, or interactions) as **not verified** until headless browser tests have run.
-- Prefer a headless browser runner over assumptions:
-  - If a Puppeteer MCP tool is available, use it to run relevant headless tests and capture screenshots/diffs.
-  - Otherwise, if Playwright is configured, run the configured Playwright test command for the project.
+- Use the project's automated verification workflow (DO NOT require manual web browsing):
+  - Primary: Run `mise exec -- yarn visual:verify --urls "/route1,/route2"` to capture screenshots in `tmp/visual-verification/`
+  - Alternative: Run Rails system tests with `mise run test-system` (Cuprite-based headless browser tests)
+  - Review generated artifacts automatically in the output
 - Run a targeted or full headless test suite that covers the changed surface.
 - Summarize results explicitly in your output:
   - On success: state that headless browser tests passed and no unexpected visual diffs were detected.
@@ -29,6 +30,7 @@ You SHOULD:
 - Prefer targeted runs based on changed files/paths when the project conventions support it.
 - Use the same commands/flags locally that CI uses for headless tests, when known.
 - Capture before/after behavior when helpful, via screenshots or visual diffs.
+- Always prefix commands with `mise exec --` to ensure consistent environment matching CI/hooks.
 
 If headless browser verification is unavailable or fails to run:
 - Say explicitly that empirical headless verification could not be completed.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use the application at https://dorkbob.herokuapp.com
 - [`docs/agent-coder-workflow.md`](docs/agent-coder-workflow.md) - **Required reading for AI agents**
 - Use `lefthook run workflow-status` and `lefthook run workflow-new-feature <branch>` instead of direct git operations
 - Before pushing, regenerate the production Tailwind bundle with `scripts/verify-tailwind-build.sh` (or let the `tailwind-build-check` pre-push step run) to confirm dark-mode utilities exist in `app/assets/builds/tailwind.css`.
-- When touching UI styles, run `bin/dev` and validate the rendered page with the built-in Puppeteer tooling (or Windsurf browser preview). Capture a quick search result screenshot to confirm dark cards look correct in dark mode.
+- When touching UI styles, use the automated visual verification workflow: `mise exec -- yarn visual:verify --urls "/,/search?query=coffee"` or run system tests via `mise run test-system`. Do NOT require manual web browsing.
 
 ### Visual verification workflow
 

--- a/WARP.md
+++ b/WARP.md
@@ -167,7 +167,7 @@ canonical policy. Warp highlights just these reminders:
 - scripts/README.md: details for sync-branch.sh and pr-lifecycle.sh
 
 Notes
-- For non-trivial visual/UI changes, prefer headless browser verification (Puppeteer MCP or Playwright) per Issue #982, and/or the Rails Cuprite system test prompt under `.github/prompts/`.
+- For non-trivial visual/UI changes, use the automated verification workflow: `mise exec -- yarn visual:verify --urls "/route1,/route2"` or `mise run test-system` (DO NOT require manual web browsing). See Issue #982 and `.github/prompts/headless-visual-verification.prompt.md`.
 - Secrets: never commit or echo secrets. If a command requires credentials, ensure they are sourced into environment variables by the user prior to execution.
 - Network/API: Tests stub external calls (WebMock); run real API calls only in development with proper environment.
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -47,7 +47,7 @@ When creating any PR, the workflow should:
 - [ ] Latest changes pulled from remote
 - [ ] Feature branch deleted locally
 - [ ] Ready for next feature (clean working tree)
-- [ ] UI work: Tailwind build verified via `scripts/verify-tailwind-build.sh` (or lefthook `tailwind-build-check`) and dark-mode cards visually confirmed with Puppeteer/Windsurf screenshot
+- [ ] UI work: Tailwind build verified via `scripts/verify-tailwind-build.sh` (or lefthook `tailwind-build-check`) and dark-mode cards visually confirmed via `mise exec -- yarn visual:verify` or system tests
 
 ### Empirical Verification & Cross-Model Escalation (Issue #981)
 
@@ -132,16 +132,17 @@ You can either write these prompts by hand or let `scripts/generate-cross-model-
 
 For any non-trivial visual/UI change (layout, CSS, DOM structure, or interactions), agents MUST follow this policy:
 
-- Treat the change as **not verified** until it has been empirically checked in a browser.
-- Prefer a headless browser runner over memory or inference:
-  - If a Puppeteer MCP tool is available, use it to run relevant headless tests and capture screenshots/diffs.
-  - Otherwise, if Playwright is configured for the project, run the configured Playwright test command to exercise affected views.
+- Treat the change as **not verified** until it has been empirically checked using headless browser tools.
+- Use the project's visual verification workflow (DO NOT require manual web browsing):
+  - Run `mise exec -- yarn visual:verify --urls "/route1,/route2"` to capture deterministic screenshots
+  - Alternatively, run Rails system tests: `mise run test-system` (Cuprite-based headless browser tests)
+  - Review generated screenshots in `tmp/visual-verification/` or system test artifacts
 - Run a targeted or full headless test suite that covers the changed surface.
 - Summarize results explicitly in the agent output:
   - If tests pass: state that headless browser tests passed and no unexpected visual diffs were detected.
   - If tests fail or baselines differ: list failing specs and point to screenshot/diff artifacts.
 - Never silently update screenshot baselines. If new baselines are needed, explain why and ask the user to confirm updating them.
-- Do not declare visual work “done” unless:
+- Do not declare visual work "done" unless:
   - Headless browser verification has run, and
   - Either tests pass or the user explicitly accepts the visual diffs.
 - For pull requests, any issues, review comments, or automated feedback related to headless visual verification **must be addressed**, and the corresponding PR threads/remarks must be marked **resolved** in GitHub before considering the PR complete.


### PR DESCRIPTION
## Summary
Updates agent documentation to emphasize the automated visual verification workflow using `mise exec --` commands instead of requiring manual web browsing.

## Changes
- **docs/AGENTS.md**: Updated headless browser verification section to explicitly reference `mise exec -- yarn visual:verify` and `mise run test-system`
- **README.md**: Changed UI verification instructions to discourage manual web browsing
- **.github/prompts/headless-visual-verification.prompt.md**: Added explicit mise commands and workflow steps
- **WARP.md**: Updated notes to reference automated workflow

## Why
The project already has automated visual verification tools (Puppeteer via yarn scripts and Cuprite system tests), but documentation was suggesting manual browser interaction which:
- Breaks automated workflows
- Creates inconsistency between agents
- Doesn't leverage existing tooling

## Testing
- Documentation changes only
- No functional code changes
- Verified all referenced commands exist in the project

_This PR was generated with [Warp](https://www.warp.dev/)._
