### PR TITLE
Downgrade Ruby from 3.3.10 to 3.3.9

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -9,7 +9,7 @@
 ruby = "core"
 
 [tools]
-ruby = "3.3.10"
+ruby = "3.3.9"
 # lefthook is installed via Homebrew
 # Node.js and yarn are NOT included here to prevent CI compilation issues
 # They should be managed separately for local development if needed


### PR DESCRIPTION
## Summary
Downgrades Ruby from version 3.3.10 to 3.3.9 (one patch version).

## Changes
- Updated `mise.toml` to specify Ruby 3.3.9

## Context
This PR downgrades Ruby by one patch version as requested. The change is minimal and only affects the Ruby version specification in mise.toml.

## Testing Notes
⚠️ **Local testing could not be completed** due to code signature issues with precompiled mise Ruby binaries on the development machine. The change itself is straightforward (single line in mise.toml), and CI will validate that Ruby 3.3.9 works properly with the codebase.

## Validation
- [ ] CI passes all tests with Ruby 3.3.9
- [ ] All workflows complete successfully

---

_This PR was generated with [Warp](https://www.warp.dev/)._
