### PR TITLE
🚨 EMERGENCY: Fix CI test suite bypass - downgrade minitest to 5.x for Rails 8.1.1 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,10 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 gem 'bundler', '~> 2.5'
 
+# Pin minitest to 5.x due to incompatibility with Rails 8.1.1
+# See issue #1337 for details
+gem 'minitest', '~> 5.26'
+
 # Bundle edge Rails instead: gem 'rails', "~> 8.0"
 # gem 'rails', "~> 8.0"
 gem 'next_rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,8 +253,7 @@ GEM
       mime-types-data (~> 3.2025, >= 3.2025.0507)
     mime-types-data (3.2025.0722)
     mini_mime (1.1.5)
-    minitest (6.0.0)
-      prism (~> 1.5)
+    minitest (5.27.0)
     mocha (3.0.1)
       ruby2_keywords (>= 0.0.5)
     msgpack (1.8.0)
@@ -561,6 +560,7 @@ DEPENDENCIES
   magic_test
   matrix
   meta_request
+  minitest (~> 5.26)
   mocha
   next_rails
   omniauth-google-oauth2
@@ -586,6 +586,9 @@ DEPENDENCIES
   web-console
   webmock
   yaml-lint
+
+RUBY VERSION
+   ruby 3.3.10p183
 
 BUNDLED WITH
    2.7.1


### PR DESCRIPTION
## 🚨 CRITICAL EMERGENCY FIX

**Fixes:** #1337  
**Priority:** URGENT - Restores branch protection  
**Impact:** CI has been showing false positives since Dec 21, 2025

---

## Problem

Rails 8.1.1 + Minitest 6.0.0 incompatibility causes test suite to:
- Exit with code 0 (SUCCESS) even when **ZERO tests run**
- Bypass branch protection completely
- Allow broken code to merge into `develop`

**Root cause:**
```
wrong number of arguments (given 3, expected 1..2) (ArgumentError)
/gems/railties-8.1.1/lib/rails/test_unit/line_filtering.rb:7:in 'run'
```

Rails 8.1.1's `railties` calls Minitest's `run` method with 3 arguments, but Minitest 6.0.0 only accepts 1-2.

---

## Solution

**Downgrade Minitest from 6.0.0 to 5.27.0** by adding explicit constraint in Gemfile:

```ruby
gem 'minitest', '~> 5.26'
```

---

## Verification

### Before Fix
```bash
$ mise exec -- bin/rails test
0 runs, 0 assertions, 0 failures, 0 errors, 0 skips ❌
```

### After Fix
```bash
$ mise exec -- bin/rails test test/simple_test.rb
1 runs, 1 assertions, 0 failures, 0 errors, 0 skips ✅

$ mise exec -- bin/rails test test/models/user_test.rb
8 runs, 8 assertions, 0 failures, 0 errors, 0 skips ✅
```

### Pre-push Hook Results (Full Test Suite)
```
rails-tests: 64 runs, 171 assertions, 0 failures, 0 errors, 0 skips ✅
rails-system-tests: 33 runs, 144 assertions, 0 failures, 0 errors, 5 skips ✅
```

---

## Impact Assessment

**Since Dec 21, 2025 (PR #1315):**
- ❌ All merged PRs had ZERO actual test coverage
- ❌ Branch protection completely bypassed
- ❌ CI showed SUCCESS with 0 tests running
- ❌ Quality gates failed silently

**Affected PRs:** #1334, #1332, #1330, #1328, and all others merged since Dec 21

---

## Why Fast-Track This

1. **Restores Branch Protection:** Tests will actually run and fail on broken code
2. **Minimal Risk:** Only changes Minitest version constraint
3. **Fully Verified:** All 97 tests (64 unit + 33 system) pass locally
4. **Blocking Issue:** Cannot safely merge ANY PR until this is fixed

---

## Follow-up Actions (tracked in #1337)

- [ ] Audit PRs merged since Dec 21 for potential issues
- [ ] Add CI validation to fail if test count is 0
- [ ] Document this incident in runbook
- [ ] Add pre-merge checklist for Dependabot PRs

---

## Testing Checklist

- [x] Tests run locally with mise exec
- [x] Test count shows > 0 runs
- [x] Pre-push hooks pass (97 total tests)
- [x] Gemfile.lock updated correctly
- [x] No other dependencies affected

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>