### PR TITLE
Fix #1232

### DIFF
--- a/lib/jitter/version.rb
+++ b/lib/jitter/version.rb
@@ -2,5 +2,5 @@ module Jitter
   module Version
   end
 
-  VERSION = '0.2.28'.freeze
+  VERSION = '0.2.29'.freeze
 end

--- a/test/initializers/app_version_test.rb
+++ b/test/initializers/app_version_test.rb
@@ -16,4 +16,16 @@ class AppVersionConfigTest < ActiveSupport::TestCase
     version_file_content = File.read(version_file_path).strip
     assert_equal Jitter::VERSION, version_file_content, 'Jitter::VERSION should match VERSION file content'
   end
+
+  def test_app_version_is_incremented_correctly
+    original_version = '0.2.28'
+    Rails.configuration.x.app_version = original_version
+    Jitter::VERSION = original_version
+    
+    Rails.application.config.initializers.update({
+      app_version: original_version
+    })
+    
+    assert_equal original_version, Rails.configuration.x.app_version
+  end
 end


### PR DESCRIPTION
Automated solution for issue #1232

**Status**: Tests failed

Test output (local orchestrator run):
```

[3m[1m[34m≈[39m[22m[23m tailwindcss [34mv4.1.16[39m

Done in [34m210ms[39m
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `require': --> /Users/temp/workspace/yelp_search_demo/test/initializers/app_version_test.rb
dynamic constant assignment
   3  class AppVersionConfigTest < ActiveSupport::TestCase
> 20    def test_app_version_is_incremented_correctly
> 30    end
  31  end
/Users/temp/workspace/yelp_search_demo/test/initializers/app_version_test.rb:23: dynamic constant assignment (SyntaxError)
    Jitter::VERSION = original_version
    ^~~~~~~~~~~~~~~

	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bootsnap-1.19.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:30:in `require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/zeitwerk-2.7.3/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.1/lib/rails/test_unit/runner.rb:71:in `block in load_tests'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.1/lib/rails/test_unit/runner.rb:69:in `each'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.1/lib/rails/test_unit/runner.rb:69:in `load_tests'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.1/lib/minitest/rails_plugin.rb:140:in `block in plugin_rails_options'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1715:in `block in parse_in_order'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:913:in `search'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1832:in `block in visit'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1831:in `reverse_each'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1831:in `visit'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1715:in `parse_in_order'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1630:in `order!'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1739:in `permute!'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1764:in `parse!'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/minitest-5.27.0/lib/minitest.rb:236:in `block in process_args'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1153:in `initialize'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/minitest-5.27.0/lib/minitest.rb:148:in `new'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/minitest-5.27.0/lib/minitest.rb:148:in `process_args'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/minitest-5.27.0/lib/minitest.rb:285:in `run'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/minitest-5.27.0/lib/minitest.rb:85:in `block in autorun'

```

Agent results:
- **coder**: Completed via Ollama: 2 file(s) changed
