### PR TITLE
Add CI-style test helper and remove local CI env

### DIFF
--- a/.env.local
+++ b/.env.local
@@ -1,4 +1,0 @@
-RAILS_ENV=test
-CI=true
-# Add your Rails master key here if you have one for testing
-# RAILS_MASTER_KEY=your_test_key_here

--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ This project uses `mise` to manage and run common development tasks. You can lis
 *   `mise run setup`: Re-run the initial development setup process.
 *   `mise run test`: Run all unit and integration tests.
 *   `mise run test-system`: Run system tests (e.g., browser-based tests).
+*   `scripts/ci-test-all.sh`: Run CI-style tests (no args = `test:all`, or pass test paths).
 *   `mise run lint`: Run all configured linters (e.g., RuboCop for Ruby, Prettier for JavaScript).
 *   `mise run fix`: Attempt to automatically fix issues found by linters.
 *   `mise run brakeman`: Run the Brakeman security scanner.

--- a/scripts/ci-test-all.sh
+++ b/scripts/ci-test-all.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -gt 0 ]; then
+  cmd=(bin/rails test "$@")
+else
+  cmd=(bin/rails test:all)
+fi
+
+CI=true RAILS_ENV=test HEADLESS=true CUPRITE=true APP_HOST=localhost \
+  mise exec -- "${cmd[@]}"


### PR DESCRIPTION
## Summary
- add CI-style test helper script for consistent local runs
- document helper in README
- remove .env.local to avoid hidden CI flags

## Testing
- lefthook pre-push (rails tests, system tests, tailwind build check)