### PR TITLE
Fix #1232

### DIFF
--- a/lib/jitter/version.rb
+++ b/lib/jitter/version.rb
@@ -2,5 +2,5 @@ module Jitter
   module Version
   end
 
-  VERSION = '0.2.28'.freeze
+  VERSION = '0.2.29'.freeze
 end

--- a/test/initializers/app_version_test.rb
+++ b/test/initializers/app_version_test.rb
@@ -16,4 +16,17 @@ class AppVersionConfigTest < ActiveSupport::TestCase
     version_file_content = File.read(version_file_path).strip
     assert_equal Jitter::VERSION, version_file_content, 'Jitter::VERSION should match VERSION file content'
   end
+
+  def test_app_version_is_increased_by_one_patch
+    previous_version = '0.2.28'.freeze
+    Rails.configuration.x.app_version = previous_version
+    
+    assert_equal '0.2.29', Rails.configuration.x.app_version, 'app_version is updated correctly'
+
+    old_value = Jitter::VERSION
+    Rails.configuration.x.app_version = old_value
+
+    assert_equal '0.2.29', Jitter::VERSION, "Jitter::VERSION is updated correctly"
+
+  end
 end


### PR DESCRIPTION
Automated solution for issue #1232

**Status**: Tests failed

Test output (local conductor run):
```

/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/definition.rb:691:in `materialize': Could not find sqlite3-2.9.0-arm64-darwin, bcrypt-3.1.21, bootsnap-1.20.1, brakeman-7.1.2, rubocop-rails-2.34.3, lefthook-2.0.13, i18n-1.14.8, nokogiri-1.19.0-arm64-darwin, zeitwerk-2.7.4, action_text-trix-2.1.16, bigdecimal-4.0.1, multi_xml-0.8.0, rdoc-7.0.3 in locally installed gems (Bundler::GemNotFound)
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/definition.rb:237:in `specs'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/definition.rb:304:in `specs_for'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:18:in `setup'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler.rb:166:in `setup'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/setup.rb:32:in `block in <top (required)>'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/ui/shell.rb:173:in `with_level'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/ui/shell.rb:119:in `silence'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/setup.rb:32:in `<top (required)>'
	from <internal:/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from <internal:/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from /Users/temp/workspace/yelp_search_demo/config/boot.rb:3:in `<top (required)>'
	from bin/rails:3:in `require_relative'
	from bin/rails:3:in `<main>'

```

Agent results:
- **coder**: Completed via Ollama: 2 file(s) changed
