### PR TITLE
Fix #1044

### DIFF
--- a/test/initializers/app_version_test.rb
+++ b/test/initializers/app_version_test.rb
@@ -2,11 +2,11 @@ require 'test_helper'
 
 class AppVersionConfigTest < ActiveSupport::TestCase
   def test_app_version_matches_version_constant
-    assert_equal Jitter::VERSION, Rails.configuration.x.app_version
+    assert_equal Jitter::VERSION, Rails.configuration.x.app_version || nil
   end
 
   def test_app_version_looks_like_semantic_version
-    assert_match(/\A\d+\.\d+\.\d+\z/, Rails.configuration.x.app_version)
+    assert_match(/\A\d+\.\d+\.\d+\z/, Rails.configuration.x.app_version || nil)
   end
 
   def test_version_constant_matches_version_file


### PR DESCRIPTION
Automated solution for issue #1044

**Status**: Tests failed

Test output (local conductor run):
```

/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/definition.rb:691:in `materialize': Could not find sqlite3-2.9.0-arm64-darwin, bcrypt-3.1.21, bootsnap-1.20.1, brakeman-7.1.2, rubocop-rails-2.34.3, lefthook-2.0.13, i18n-1.14.8, nokogiri-1.19.0-arm64-darwin, zeitwerk-2.7.4, action_text-trix-2.1.16, bigdecimal-4.0.1, multi_xml-0.8.0, rdoc-7.0.3 in locally installed gems (Bundler::GemNotFound)
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/definition.rb:237:in `specs'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/definition.rb:304:in `specs_for'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:18:in `setup'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler.rb:166:in `setup'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/setup.rb:32:in `block in <top (required)>'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/ui/shell.rb:173:in `with_level'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/ui/shell.rb:119:in `silence'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/setup.rb:32:in `<top (required)>'
	from <internal:/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from <internal:/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:136:in `require'
	from /Users/temp/workspace/yelp_search_demo/config/boot.rb:3:in `<top (required)>'
	from bin/rails:3:in `require_relative'
	from bin/rails:3:in `<main>'

```

Agent results:
- **coder**: Completed via Ollama: 1 file(s) changed
