### PR TITLE
fix(ci): add actions:write permission to auto-update workflow

### DIFF
--- a/.github/workflows/auto-update-prs.yml
+++ b/.github/workflows/auto-update-prs.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  actions: write
 
 jobs:
   auto-update:


### PR DESCRIPTION
This PR adds the 'actions:write' permission to the auto-update-prs workflow. This is required for the 'workflow_dispatch' trigger to work when the script attempts to run the 'main.yml' workflow.