### PR TITLE
Fix #1232

### DIFF
--- a/lib/jitter/version.rb
+++ b/lib/jitter/version.rb
@@ -2,5 +2,5 @@ module Jitter
   module Version
   end
 
-  VERSION = '0.2.84'.freeze
+  VERSION = '0.3.84'.freeze
 end


### PR DESCRIPTION
Automated solution for issue #1232

**Status**: Tests failed

Test output (local conductor run):
```

🐢  Precompiling assets.
Finished in 0.88 seconds
Running 97 tests in parallel using 3 processes
Run options: --seed 52871

# Running:

.........[Screenshot Image]: tmp/capybara/screenshots/failures_test_a_mobile_user_can_share_their_location-_search_for_tacos-_and_get_directions.png 
E

Error:
MobileUserJourneyTest#test_a_mobile_user_can_share_their_location,_search_for_tacos,_and_get_directions:
Ferrum::PendingConnectionsError: Request to http://localhost:49646/ reached server, but there are still pending connections: http://localhost:49646/, http://localhost:49646/assets/application-6a977ec6.js, http://localhost:49646/assets/turbo.min-9fd88cd5.js, http://localhost:49646/assets/stimulus.min-4b1e420e.js, http://localhost:49646/assets/stimulus-loading-1fc53fe7.js, http://localhost:49646/assets/controllers/application-a7a6f248.js, http://localhost:49646/assets/controllers/geolocation_controller-6293634a.js, http://localhost:49646/assets/controllers/hello_controller-dc142e8c.js, https://ga.jspm.io/npm:@fortawesome/fontawesome-free@6.1.1/js/all.js, https://cdnjs.cloudflare.com/ajax/libs/materialize/1.0.0/js/materialize.min.js, http://localhost:49646/assets/controllers/index-b474d080.js, http://localhost:49646/assets/controllers/theme_controller-1d449c68.js
    test/system/mobile_user_journey_test.rb:29:in `block in <class:MobileUserJourneyTest>'

bin/rails test test/system/mobile_user_journey_test.rb:28

E

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    test/system/favorite_toggle_test.rb:12:in `block in <class:FavoriteToggleTest>'

Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/favorite_toggle_test.rb:10

............E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    test/system/debug_favorite_test.rb:11:in `block in <class:DebugFavoriteTest>'

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Ferrum::TimeoutError: Timed out waiting for response. It's possible that this happened because something took a very long time (for example a page load was slow). If so, setting the :timeout option to a higher value might help.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:96:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

bin/rails test test/system/debug_favorite_test.rb:9

.......F

Failure:
AppVersionConfigTest#test_version_constant_matches_version_file [test/initializers/app_version_test.rb:19]:
Jitter::VERSION should match VERSION file content.
Expected: "0.3.84"
  Actual: "0.2.84"

bin/rails test test/initializers/app_version_test.rb:12

.S[Screenshot Image]: tmp/capybara/screenshots/failures_test_favorite_icon_changes_based_on_search_term.png 
F

Failure:
FavoriteToggleTest#test_favorite_icon_changes_base
... [truncated due to length]
```

Detected failing tests from local run (heuristic):
```txt
Error:
MobileUserJourneyTest#test_a_mobile_user_can_share_their_location,_search_for_tacos,_and_get_directions:
Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Error:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
```

New failing tests vs base (heuristic):
```txt
AppVersionConfigTest#test_version_constant_matches_version_file [test/initializers/app_version_test.rb:19]:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Error:
Failure:
FavoriteToggleTest#test_favorite_icon_changes_based_on_search_term [test/system/favorite_toggle_test.rb:94]:
FavoriteToggleTest#test_logged_in_user_can_toggle_favorite_with_contextual_icons:
MobileUserJourneyTest#test_a_mobile_user_can_share_their_location,_search_for_tacos,_and_get_directions:
SearchesTest#test_An_anonymous_user_at_the_static_home_can_search_by_query_and_view_results:
UsersTest#test_manual_sign_in:
```

Agent results:
- **coder**: Completed via Ollama: 1 file(s) changed
