### PR TITLE
Fix #1232

### DIFF
--- a/lib/jitter/version.rb
+++ b/lib/jitter/version.rb
@@ -2,5 +2,5 @@ module Jitter
   module Version
   end
 
-  VERSION = '0.2.84'.freeze
+  VERSION = '0.3.85'.freeze
 end


### PR DESCRIPTION
Automated solution for issue #1232

**Status**: Tests failed

Test output (local conductor run):
```

🐢  Precompiling assets.
Finished in 0.98 seconds
Running 97 tests in parallel using 3 processes
Run options: --seed 16905

# Running:

.E

Error:
LocalesTest#test_en_is_the_default_locale:
Ferrum::BrowserError: Failed to find context with id 82E0B0F02CA72C4803036E2F1F32749D
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:175:in `raise_browser_error'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:99:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:81:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/contexts.rb:52:in `dispose'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/contexts.rb:63:in `block in reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:256:in `block in each_key'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/collection/map/non_concurrent_map_backend.rb:101:in `block in each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/collection/map/non_concurrent_map_backend.rb:100:in `each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/collection/map/non_concurrent_map_backend.rb:100:in `each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:276:in `each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:256:in `each_key'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/contexts.rb:63:in `reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/browser.rb:207:in `reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/browser.rb:37:in `reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:134:in `reset!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:132:in `reset!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara.rb:327:in `block in reset_sessions!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara.rb:327:in `reverse_each'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara.rb:327:in `reset_sessions!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:16:in `after_teardown'

bin/rails test test/system/locales_test.rb:30

........E

Error:
DisabledFeaturesTest#test_I_should_not_see_Early_Access_Preview:
Ferrum::BrowserError: Session with given id not found.
    test/system/disabled_features_test.rb:10:in `block in <class:DisabledFeaturesTest>'

Error:
DisabledFeaturesTest#test_I_should_not_see_Early_Access_Preview:
Ferrum::BrowserError: Session with given id not found.
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:175:in `raise_browser_error'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:99:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

Error:
DisabledFeaturesTest#test_I_should_not_see_Early_Access_Preview:
Ferrum::BrowserError: Failed to find context with id 82E0B0F02CA72C4803036E2F1F32749D
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:175:in `raise_browser_error'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:99:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:81:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/contexts.rb:52:in `dispose'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/contexts.rb:63:in `block in reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:256:in `block in each_key'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/collection/map/non_concurrent_map_backend.rb:101:in `block in each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/collection/map/non_concurrent_map_backend.rb:100:in `each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/collection/map/non_concurrent_map_backend.rb:100:in `each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:276:in `each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:256:in `each_key'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/contexts.rb:63:in `reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/browser.rb:207:in `reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/browser.rb:37:in `reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:134:in `reset!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:132:in `reset!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara.rb:327:in `block in reset_sessions!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gem
... [truncated due to length]
```

Detected failing tests from local run (heuristic):
```txt
Error:
LocalesTest#test_en_is_the_default_locale:
Error:
DisabledFeaturesTest#test_I_should_not_see_Early_Access_Preview:
Error:
DisabledFeaturesTest#test_I_should_not_see_Early_Access_Preview:
Error:
DisabledFeaturesTest#test_I_should_not_see_Early_Access_Preview:
Error:
TailwindCssDeliveryTest#test_Tailwind_CSS_classes_are_present_without_CDN:
```

New failing tests vs base (heuristic):
```txt
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
DisabledFeaturesTest#test_I_should_not_see_Early_Access_Preview:
Error:
LocalesTest#test_en_is_the_default_locale:
TailwindCssDeliveryTest#test_Tailwind_CSS_classes_are_present_without_CDN:
```

Agent results:
- **coder**: Completed via Ollama: 1 file(s) changed
