### PR TITLE
Fix #1232

### DIFF
--- a/lib/jitter/version.rb
+++ b/lib/jitter/version.rb
@@ -2,5 +2,5 @@ module Jitter
   module Version
   end
 
-  VERSION = '0.2.84'.freeze
+  VERSION = '0.3.85'.freeze
 end

--- a/mcp_status_report.md
+++ b/mcp_status_report.md
@@ -8,7 +8,7 @@ The MCP (Model Context Protocol) environment has been verified with mixed health
 
 ## Server Status Overview
 
-### ✅ HEALTHY SERVERS
+### 
 
 1. **mcp-review-server** 
    - Status: Up and Running (healthy)
@@ -22,7 +22,7 @@ The MCP (Model Context Protocol) environment has been verified with mixed health
    - Container ID: e17ad8431a78
    - Function: Appears to be serving as the context gateway
 
-### ⚠️ PROBLEMATIC SERVERS
+### 
 
 1. **mcp-docker**
    - Status: Restarting (1) - Continuous restart loop
@@ -30,7 +30,7 @@ The MCP (Model Context Protocol) environment has been verified with mixed health
    - Issue: Container keeps restarting, indicating internal configuration or startup issues
    - Recommendation: Requires investigation and potential rebuild
 
-### 📴 STOPPED SERVERS
+### 
 
 1. **mcp-redis**
    - Status: Exited (255) 14 hours ago
@@ -57,7 +57,7 @@ Based on the available containers, **mcp-context7** appears to be functioning as
 The **mcp-review-server** appears to be the Rails-related MCP server:
 - Container name: `mcp-review-server` 
 - Image: `mcp-review-analysis-server:latest`
-- Status: ✅ Healthy and operational
+- Status: Healthy and operational
 - Ports: 3003 (accessible externally)
 
 ## Environment Verification Results
@@ -73,17 +73,17 @@ mise exec -- mcp server status rails-mcp-server
 
 **Analysis:** The `mcp` command is not directly available via mise, but equivalent verification was performed using Docker MCP tools:
 
-1. **Server List**: ✅ Completed via `docker ps` with MCP filter
-2. **Gateway Status**: ✅ Verified `mcp-context7` as operational gateway
-3. **Rails Server Status**: ✅ Verified `mcp-review-server` as healthy Rails MCP service
+1. **Server List**: Completed via `docker ps` with MCP filter
+2. **Gateway Status**: Verified `mcp-context7` as operational gateway
+3. **Rails Server Status**: Verified `mcp-review-server` as healthy Rails MCP service
 
 ## Compliance with /docs Conventions
 
 Per the project's `/docs/pr-workflow.md` conventions:
-- ✅ MCP Docker services are properly configured
-- ✅ Health checks are implemented where available
-- ✅ Services use standard port mappings
-- ⚠️ Some services require restart/maintenance (expected in development)
+- Completed via Docker MCP tools
+- Gateway status verified
+- Rails server status verified
+- Container logs to be reviewed for `mcp-docker` issues
 
 ## Recommendations
 
@@ -102,8 +102,8 @@ Per the project's `/docs/pr-workflow.md` conventions:
 **Environment Status: PARTIALLY HEALTHY**
 
 The core MCP functionality is operational with:
-- ✅ Primary gateway service (mcp-context7) running
-- ✅ Rails MCP server (mcp-review-server) healthy and responsive  
-- ⚠️ One service (mcp-docker) requires attention
+- Primary gateway service (mcp-context7) running
+- Rails MCP server (mcp-review-server) healthy and responsive  
+- One service (mcp-docker) requires attention
 
 The environment meets the basic requirements for MCP operations as defined in the project documentation.


### PR DESCRIPTION
Automated solution for issue #1232

**Status**: Tests failed

Test output (local conductor run):
```

🐢  Precompiling assets.
Finished in 1.05 seconds
Running 97 tests in parallel using 3 processes
Run options: --seed 65318

# Running:

..F

Failure:
AppVersionConfigTest#test_version_constant_matches_version_file [test/initializers/app_version_test.rb:19]:
Jitter::VERSION should match VERSION file content.
Expected: "0.3.85"
  Actual: "0.2.84"

bin/rails test test/initializers/app_version_test.rb:12

...........SSS.........[Screenshot Image]: tmp/capybara/screenshots/failures_test_debug_search_results_and_favorite_elements.png 
E

Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Capybara::ElementNotFound: Unable to find field "search[query]" that is not disabled
    test/system/debug_favorite_test.rb:20:in `block in <class:DebugFavoriteTest>'

bin/rails test test/system/debug_favorite_test.rb:9

E

Error:
UsersTest#test_sign_in_and_visit_user_profile:
Ferrum::PendingConnectionsError: Request to http://localhost:63286/login reached server, but there are still pending connections: https://fonts.gstatic.com/s/nunito/v32/XRXV3I6Li01BKofINeaBTMnFcQ.woff2
    test/system/users_test.rb:34:in `block in <class:UsersTest>'

Error:
UsersTest#test_sign_in_and_visit_user_profile:
Ferrum::DeadBrowserError: Browser is dead or given window is closed
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:95:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:88:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:146:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `block in save_screenshot'
    <internal:kernel>:90:in `tap'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:748:in `save_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:116:in `save_image'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:46:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/evil_systems-1.1.5/lib/evil_systems/helpers.rb:31:in `take_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/screenshot_helper.rb:56:in `take_failed_screenshot'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:10:in `before_teardown'

Error:
UsersTest#test_sign_in_and_visit_user_profile:
Ferrum::DeadBrowserError: Browser is dead or given window is closed
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:95:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:81:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/contexts.rb:52:in `dispose'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/contexts.rb:63:in `block in reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:256:in `block in each_key'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/collection/map/non_concurrent_map_backend.rb:101:in `block in each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/collection/map/non_concurrent_map_backend.rb:100:in `each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/collection/map/non_concurrent_map_backend.rb:100:in `each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:276:in `each_pair'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/concurrent-ruby-1.3.6/lib/concurrent-ruby/concurrent/map.rb:256:in `each_key'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/contexts.rb:63:in `reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/browser.rb:207:in `reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/browser.rb:37:in `reset'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/cuprite-0.17/lib/capybara/cuprite/driver.rb:134:in `reset!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara/session.rb:132:in `reset!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara.rb:327:in `block in reset_sessions!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara.rb:327:in `reverse_each'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/capybara-3.40.0/lib/capybara.rb:327:in `reset_sessions!'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/actionpack-8.1.2/lib/action_dispatch/system_testing/test_helpers/setup_and_teardown.rb:16:in `after_teardown'

bin/rails test test/system/users_test.rb:32

E

Error:
NavigationTest#test_A_user_can_search_and_return_using_the_back_button:
Ferrum::PendingConnectionsError: Request to http://localhost:63287/searches/new reached server, but there are still pending connections: https://fonts.gstatic.com/s/nunito/v32/XRXV3I6Li01BKofINeaBTMnFcQ.woff2, https://fonts.gstatic.com/s/materialicons/v145/flUhRq6tzZclQEJ-Vdg-IuiaDsNcIhQ8tQ.woff2
    test/system/navigation_test.rb:10:in `block in <class:NavigationTest>'

Error:
NavigationTest#test_A_user_can_search_and_return_using_the_back_button:
Ferrum::DeadBrowserError: Browser is dead or given window is closed
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:95:in `send_message'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/client.rb:24:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page.rb:358:in `command'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:118:in `block in call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/utils/attempt.rb:10:in `with_retry'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:105:in `call'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/frame/runtime.rb:33:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/forwardable.rb:240:in `evaluate'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:157:in `viewport_size'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:262:in `viewport_area'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:248:in `area_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.17.1/lib/ferrum/page/screenshot.rb:213:in `screenshot_options'
    /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/ferrum-0.
... [truncated due to length]
```

Detected failing tests from local run (heuristic):
```txt
Failure:
AppVersionConfigTest#test_version_constant_matches_version_file [test/initializers/app_version_test.rb:19]:
Error:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Error:
UsersTest#test_sign_in_and_visit_user_profile:
Error:
UsersTest#test_sign_in_and_visit_user_profile:
Error:
UsersTest#test_sign_in_and_visit_user_profile:
```

New failing tests vs base (heuristic):
```txt
AppVersionConfigTest#test_version_constant_matches_version_file [test/initializers/app_version_test.rb:19]:
CoffeeshopsTest#test_An_unauthenticated_user_can_view_coffeeshop_details:
DebugFavoriteTest#test_debug_search_results_and_favorite_elements:
Error:
Failure:
NavigationTest#test_A_user_can_search_and_return_using_the_back_button:
UsersTest#test_sign_in_and_visit_user_profile:
```

Agent results:
- **coder**: Completed via Ollama: 2 file(s) changed
