### PR TITLE
UI: Convert search bar to horizontal layout

### DIFF
--- a/app/assets/stylesheets/search-bar.css
+++ b/app/assets/stylesheets/search-bar.css
@@ -47,10 +47,17 @@
   transition: background-color 0.2s;
   flex-shrink: 0;
   color: var(--color-text);
+  width: 40px;
+  height: 40px;
 }
 
 .clear-button:hover {
   background-color: rgba(128, 128, 128, 0.1);
+}
+
+.clear-button-hidden {
+  visibility: hidden;
+  opacity: 0;
 }
 
 .geolocation-button {
@@ -96,4 +103,10 @@
 .search-button:hover {
   opacity: 0.9;
   transform: translateY(-1px);
+}
+
+@media (max-width: 320px) {
+  .geolocation-button {
+    display: none;
+  }
 }

--- a/app/javascript/controllers/search_form_controller.js
+++ b/app/javascript/controllers/search_form_controller.js
@@ -1,0 +1,18 @@
+import { Controller } from '@hotwired/stimulus';
+
+export default class extends Controller {
+  static targets = ['input', 'clearButton'];
+
+  connect() {
+    this.toggleClearButton();
+  }
+
+  toggleClearButton() {
+    const hasValue = this.inputTarget.value.length > 0;
+    if (hasValue) {
+      this.clearButtonTarget.classList.remove('clear-button-hidden');
+    } else {
+      this.clearButtonTarget.classList.add('clear-button-hidden');
+    }
+  }
+}

--- a/app/views/searches/_form.html.erb
+++ b/app/views/searches/_form.html.erb
@@ -1,23 +1,29 @@
 <div class="form-group">
-  <%= form_for @search, html: { class: 'w-full search-bar-container', data: { turbo: false } } do |f| %>
+  <%= form_for @search, html: { class: 'w-full search-bar-container', data: { turbo: false, controller: 'search-form' } } do |f| %>
     <div class="search-bar">
+      <button type="button" class="geolocation-button" data-action="geolocation#geolocate" aria-label="Use my current location">
+        <i class="material-icons">my_location</i>
+      </button>
 
       <%= f.search_field :query,
                          placeholder: t('views.searches.placeholder'),
                          required: true,
-                         class: 'search-input' %>
+                         class: 'search-input',
+                         data: {
+                           'search-form-target': 'input',
+                           action: 'input->search-form#toggleClearButton',
+                         } %>
 
       <%= link_to new_search_path,
                   method: :get,
-                  class: 'clear-button',
-                  data: { turbo_frame: dom_id(@search) },
+                  class: 'clear-button clear-button-hidden',
+                  data: {
+                    turbo_frame: dom_id(@search),
+                    'search-form-target': 'clearButton',
+                  },
                   aria: { label: t('views.searches.clear', default: 'Clear') } do %>
         <i class="material-icons">clear</i>
       <% end %>
-
-      <button type="button" class="geolocation-button" data-action="geolocation#geolocate" aria-label="Use my current location">
-        <i class="material-icons">my_location</i>
-      </button>
 
       <%= f.button :submit, class: 'search-button', aria: { label: t('views.searches.submit', default: 'Search') } do %>
         <i class="material-icons">search</i>


### PR DESCRIPTION
## Summary
Convert search bar to horizontal single-row layout with proper button ordering and conditional clear button visibility.

## Changes

### New File
- `app/javascript/controllers/search_form_controller.js` - Stimulus controller to show/hide clear button based on input value

### Modified Files
- `app/views/searches/_form.html.erb` - Reordered elements: geolocation → input → clear → search
- `app/assets/stylesheets/search-bar.css` - Added hidden class and mobile responsive rule

## Layout
```
[Geolocation] [Input field ----------] [Clear (if text)] [Search Button]
```

## Features
- All buttons aligned horizontally in single row
- Clear button hidden when input empty, visible when has text (instant toggle)
- Geolocation button hidden on mobile (< 320px)
- All buttons normalized to 40x40px

## Testing
- All Rails tests pass (64 runs, 210 assertions)
- All system tests pass (33 runs, 144 assertions)
- All pre-push hooks passed

## Related
Fixes #1720