### PR TITLE
Agent autonomy: add long-session session-retro contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ For deep policy and methodology, see `docs/AGENTS.md`.
 - **Run a long-session retro before final handoff**
 
   - Before the final response in a long or blocker-heavy session, agents SHOULD invoke:
-    - `[$session-retro](/Users/temp/.codex/skills/session-retro/SKILL.md)`
+    - the `session-retro` skill via the agent platform's skill or tool interface
   - Treat a session as retro-required when any of these are true:
     - runtime exceeds roughly 20 minutes
     - more than 2 blocker classes appear


### PR DESCRIPTION
## Summary
- add a repo-level long-session `session-retro` contract to `AGENTS.md`
- require capability re-checks after auth, sandbox, or network changes
- treat worktree conflicts and dead preview URLs as routing problems with explicit fallback behavior

## Validation
- mise exec -- git push -u origin feature/session-retro-instructions
- pre-push hooks passed, including `rails-tests` and `rails-system-tests`

Closes #1752
