### PR TITLE
Fix #1221

### DIFF
--- a/.ai-task-coder-warp.txt
+++ b/.ai-task-coder-warp.txt
@@ -1,3 +1,3 @@
-Simulated Warp execution for issue #1744
-Task: Bump patch version by +1 (semver) in BOTH `VERSION` and `lib/jitter/version.rb`, keeping them in sync. Run bin/rails test test/initializers/app_version_test.rb and report results.
+Simulated Warp execution for issue #1221
+Task: Edit app/javascript/controllers/geolocation_controller.js to track explicit UI states and update existing JS/system coverage. Update the Stimulus controller to display a loading/requesting state while geolocation is in progress, a success state after latitude/longitude are captured, and a denied/unavailable state inline when geolocation cannot be used. Run the targeted tests that cover the search form/geolocation flow.
 Agent: coder


### PR DESCRIPTION
Automated solution for issue #1221

**Status**: Tests failed

Test output (local conductor run):
```

mise WARN  env value contains '$' which will be expanded in a future release. Set `env_shell_expand = true` to opt in or `env_shell_expand = false` to keep current behavior and suppress this warning.
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:71:in `rescue in block (2 levels) in require': There was an error while trying to load the gem 'next_rails'. (Bundler::GemRequireError)
Gem Load Error is: cannot load such file -- byebug
Backtrace for gem load error is:
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bootsnap-1.23.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:17:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/zeitwerk-2.7.5/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/next_rails-1.4.7/lib/next_rails/bundle_report/cli.rb:6:in `<main>'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bootsnap-1.23.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/zeitwerk-2.7.5/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/next_rails-1.4.7/lib/next_rails.rb:7:in `<main>'
<internal:/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
<internal:/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/zeitwerk-2.7.5/lib/zeitwerk/core_ext/kernel.rb:34:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:63:in `block (2 levels) in require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:58:in `each'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:58:in `block in require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:52:in `each'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:52:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler.rb:214:in `require'
/Users/temp/.windsurf/repos/yelp_search_demo_conductor/config/application.rb:9:in `<main>'
/Users/temp/.windsurf/repos/yelp_search_demo_conductor/config/environment.rb:2:in `require_relative'
/Users/temp/.windsurf/repos/yelp_search_demo_conductor/config/environment.rb:2:in `<main>'
/Users/temp/.windsurf/repos/yelp_search_demo_conductor/test/test_helper.rb:11:in `require_relative'
/Users/temp/.windsurf/repos/yelp_search_demo_conductor/test/test_helper.rb:11:in `<main>'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bootsnap-1.23.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in `require'
/Users/temp/.windsurf/repos/yelp_search_demo_conductor/test/initializers/app_version_test.rb:1:in `<main>'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bootsnap-1.23.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in `require'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.2.1/lib/rails/test_unit/runner.rb:71:in `block in load_tests'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.2.1/lib/rails/test_unit/runner.rb:69:in `each'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.2.1/lib/rails/test_unit/runner.rb:69:in `load_tests'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.2.1/lib/minitest/rails_plugin.rb:147:in `block in plugin_rails_options'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1715:in `block in parse_in_order'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:913:in `search'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1832:in `block in visit'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1831:in `reverse_each'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1831:in `visit'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1715:in `parse_in_order'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1630:in `order!'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1739:in `permute!'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1764:in `parse!'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/minitest-6.0.2/lib/minitest.rb:254:in `block in process_args'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1153:in `initialize'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/minitest-6.0.2/lib/minitest.rb:160:in `new'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/minitest-6.0.2/lib/minitest.rb:160:in `process_args'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/minitest-6.0.2/lib/minitest.rb:300:in `run'
/Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/minitest-6.0.2/lib/minitest.rb:84:in `block in autorun'
Bundler Error Backtrace:

	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:62:in `block (2 levels) in require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:58:in `each'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:58:in `block in require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:52:in `each'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler/runtime.rb:52:in `require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bundler-2.7.1/lib/bundler.rb:214:in `require'
	from /Users/temp/.windsurf/repos/yelp_search_demo_conductor/config/application.rb:9:in `<main>'
	from /Users/temp/.windsurf/repos/yelp_search_demo_conductor/config/environment.rb:2:in `require_relative'
	from /Users/temp/.windsurf/repos/yelp_search_demo_conductor/config/environment.rb:2:in `<main>'
	from /Users/temp/.windsurf/repos/yelp_search_demo_conductor/test/test_helper.rb:11:in `require_relative'
	from /Users/temp/.windsurf/repos/yelp_search_demo_conductor/test/test_helper.rb:11:in `<main>'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bootsnap-1.23.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in `require'
	from /Users/temp/.windsurf/repos/yelp_search_demo_conductor/test/initializers/app_version_test.rb:1:in `<main>'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/bundled_gems.rb:69:in `block (2 levels) in replace_require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/bootsnap-1.23.0/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:33:in `require'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.2.1/lib/rails/test_unit/runner.rb:71:in `block in load_tests'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.2.1/lib/rails/test_unit/runner.rb:69:in `each'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.2.1/lib/rails/test_unit/runner.rb:69:in `load_tests'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/gems/3.3.0/gems/railties-8.1.2.1/lib/minitest/rails_plugin.rb:147:in `block in plugin_rails_options'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1715:in `block in parse_in_order'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:913:in `search'
	from /Users/temp/.local/share/mise/installs/ruby/3.3.10/lib/ruby/3.3.0/optparse.rb:1832:in `block in visit'
	from /Users/temp/.local/share/m
... [truncated due to length]
```

Agent results:
- **coder**: Simulated Warp execution completed (with tests)
