### PR TITLE
Fix #1780: run test on develop pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -215,9 +215,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: [get-risk-assessment]
     if: |
+      always() && !cancelled() && (
       (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
       ((github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && 
-       (needs.get-risk-assessment.result == 'success' || needs.get-risk-assessment.result == 'skipped'))
+       (needs.get-risk-assessment.result == 'success' || needs.get-risk-assessment.result == 'skipped')))
     permissions:
       contents: read # Added for least privilege
       statuses: write # Required for commit status reporting


### PR DESCRIPTION
## Summary
- make the `test` job use the same `always() && !cancelled()` guard that `test-next` already uses
- ensure `develop` push workflows still run the deploy-critical `test` job even when `get-risk-assessment` is skipped
- unblock the downstream `Verify Heroku Deployment` job from being skipped purely because of skipped risk-assessment state

## Root cause
`test` has `needs: [get-risk-assessment]`, but unlike `test-next`, it did not use `always()` in its job-level `if`. On `develop` pushes, `get-risk-assessment` is skipped, so GitHub skips `test` before evaluating the intended push condition. That in turn causes `Verify Heroku Deployment` to skip because it needs both `test` and `test-next`.

## Validation
- `mise exec -- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/main.yml'); puts \"main.yml ok\""`
- `mise exec -- git diff --check`

Closes #1780.
