### PR TITLE
Fix #1782: run Heroku verification on develop pushes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -338,7 +338,12 @@ jobs:
     name: Verify Heroku Deployment
     runs-on: ubuntu-latest
     needs: [test, test-next] # Ensure tests pass before verifying deployment
-    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
+    if: |
+      always() && !cancelled() &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/develop' &&
+      needs.test.result == 'success' &&
+      needs.test-next.result == 'success'
     permissions:
       contents: read # Added for least privilege
     env:


### PR DESCRIPTION
## Summary
- make `Verify Heroku Deployment` use an explicit `always() && !cancelled()` job guard
- require `test` and `test-next` to have actually succeeded before the deploy verification runs
- stop `develop` push workflows from silently skipping the Heroku health-check phase after upstream jobs override a skipped ancestor

## Root cause
Even after fixing `test`, the `develop` push workflow still skipped `Verify Heroku Deployment`. The likely cause was the same skipped-ancestor behavior one level down: the job depended on `test` and `test-next`, but did not use `always()` to continue past the skipped `get-risk-assessment` ancestor in the dependency chain.

## Validation
- `mise exec -- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/main.yml'); puts \"main.yml ok\""`
- `mise exec -- git diff --check`

Closes #1782.
