### PR TITLE
Build: harden evergreen Rails and Ruby upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,7 +19,8 @@ updates:
       gha-minor-patch:
         update-types: ["minor", "patch"]
     
-  # Ruby/Bundler dependencies
+  # Ruby gems for the stable lane.
+  # Ruby runtime version bumps are handled separately by the Ruby Evergreen workflow.
   - package-ecosystem: bundler
     directory: /
     schedule:

--- a/.github/workflows/dependabot.next.yml
+++ b/.github/workflows/dependabot.next.yml
@@ -1,56 +1,59 @@
-name: Dependabot Update Gemfile.next.lock
+name: Dependabot Refresh Gemfile.next.lock
+
 on:
-  pull_request:
-    types: [opened, synchronize, reopened]
-  # Also trigger on push to Dependabot branches for better reliability
   push:
     branches:
-      - 'dependabot/**'
+      - "dependabot/**"
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:
-  pull-requests: write
   contents: write
-  actions: write
 
 jobs:
-  dependabot:
+  refresh-next-lockfile:
+    if: startsWith(github.ref_name, 'dependabot/') && (github.actor == 'dependabot[bot]' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
-    if: startsWith(github.head_ref, 'dependabot/') || startsWith(github.ref, 'refs/heads/dependabot/')
     steps:
-      - name: checkout code
+      - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Setup mise environment
         uses: jdx/mise-action@v4
+
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y -qq libyaml-dev libpq-dev
-          
-      - name: Update Gemfile.next.lock
-        id: update_lockfile
-        env:
-          CI: true
-          BUNDLE_GEMFILE: Gemfile.next
-          BUNDLE_FROZEN: 'false'
-        run: |
-          echo "Updating Gemfile.next.lock..."
-          # Use mise to ensure correct Ruby version
-          mise exec -- bundle install --update
 
-      - name: Commit and push updated Gemfile.next.lock
+      - name: Refresh Gemfile.next.lock
+        env:
+          BUNDLE_GEMFILE: Gemfile.next
+          BUNDLE_FROZEN: "false"
+          CI: "true"
+        run: mise exec -- bundle install
+
+      - name: Validate next lane smoke tests
+        env:
+          BUNDLE_GEMFILE: Gemfile.next
+          BUNDLE_FROZEN: "false"
+          CI: "true"
+        run: mise run test-next-smoke
+
+      - name: Commit refreshed Gemfile.next.lock
         run: |
-          # Check if there are changes
-          if [[ -n "$(git status --porcelain Gemfile.next.lock)" ]]; then
-            echo "Changes detected in Gemfile.next.lock"
-            git config --global user.name "github-actions[bot]"
-            git config --global user.email "github-actions[bot]@users.noreply.github.com"
-            git add Gemfile.next.lock
-            git commit -m "Update Gemfile.next.lock"
-            git push origin ${{ github.head_ref || github.ref_name }}
-          else
-            echo "No changes to commit in Gemfile.next.lock"
+          if git diff --quiet -- Gemfile.next.lock; then
+            echo "Gemfile.next.lock is already current."
+            exit 0
           fi
+
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git add Gemfile.next.lock
+          git commit -m "Refresh Gemfile.next.lock for Dependabot"
+          git push origin HEAD:${{ github.ref_name }}

--- a/.github/workflows/ruby-evergreen.yml
+++ b/.github/workflows/ruby-evergreen.yml
@@ -1,0 +1,84 @@
+name: Ruby Evergreen
+
+on:
+  schedule:
+    - cron: "30 15 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  ruby-patch-upgrade:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup mise environment
+        uses: jdx/mise-action@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq libyaml-dev libpq-dev
+
+      - name: Update Ruby version files to latest patch
+        id: update_ruby
+        run: |
+          mise exec -- ruby scripts/update_ruby_version.rb --latest-patch --apply
+          echo "version=$(ruby -e 'puts File.read(\"mise.toml\")[/ruby = \"([^\"]+)\"/, 1]')" >> "$GITHUB_OUTPUT"
+          if git diff --quiet -- mise.toml Gemfile Gemfile.next; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Bundle install for stable lane
+        if: steps.update_ruby.outputs.changed == 'true'
+        run: mise exec -- bundle install
+
+      - name: Bundle install for next lane
+        if: steps.update_ruby.outputs.changed == 'true'
+        env:
+          BUNDLE_GEMFILE: Gemfile.next
+          BUNDLE_FROZEN: "false"
+        run: mise exec -- bundle install
+
+      - name: Run stable smoke tests
+        if: steps.update_ruby.outputs.changed == 'true'
+        run: mise run test-smoke
+
+      - name: Run next-lane smoke tests
+        if: steps.update_ruby.outputs.changed == 'true'
+        run: mise run test-next-smoke
+
+      - name: Create pull request
+        if: steps.update_ruby.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          commit-message: "Build(ruby): bump Ruby to ${{ steps.update_ruby.outputs.version }}"
+          title: "Build(ruby): bump Ruby to ${{ steps.update_ruby.outputs.version }}"
+          body: |
+            ## Summary
+
+            - bumps Ruby to the latest patch release in the current minor line
+            - updates `mise.toml`, `Gemfile`, `Gemfile.next`, and refreshed lockfiles
+            - runs stable and next-lane smoke tests before opening the PR
+
+            Related to #2238.
+          branch: chore/ruby-evergreen-${{ steps.update_ruby.outputs.version }}
+          delete-branch: true
+          add-paths: |
+            Gemfile
+            Gemfile.lock
+            Gemfile.next
+            Gemfile.next.lock
+            mise.toml

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,8 @@ git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
 # ruby File.read('.ruby-version').strip
 
-# I want dependabot to update ruby to the latest patch version and set it in the Gemfile.lock
-# I think this will allow different machines to run tests with different ruby patch versions
+# Ruby upgrades are handled by the evergreen workflow, not Dependabot.
+# Keep this declaration synchronized with mise.toml for Bundler compatibility.
 
 # ruby File.read('.ruby-version').strip
 

--- a/docs/ruby-version-management.md
+++ b/docs/ruby-version-management.md
@@ -4,7 +4,9 @@ This document describes the process for managing Ruby versions in this project u
 
 ## Overview
 
-This project uses `mise` with the **core Ruby plugin** to manage Ruby versions. The Ruby version is specified in `mise.toml` as the single source of truth.
+This project uses `mise` with the **core Ruby plugin** to manage Ruby versions. The Ruby version is specified in `mise.toml` as the runtime source of truth, and the `ruby` directives in `Gemfile` and `Gemfile.next` are synchronized compatibility declarations for Bundler.
+
+Dependabot updates gems in the stable lane, including Rails when the Bundler graph changes. It does **not** manage the repository Ruby version. Ruby patch upgrades are handled by the `Ruby Evergreen` workflow and the `mise run ruby-evergreen-patch` task.
 
 ## Quick Reference
 
@@ -15,7 +17,10 @@ mise exec -- ruby -v
 # List available Ruby versions (sorted, newest last)
 mise ls-remote ruby
 
-# Update Ruby version in mise.toml
+# Update Ruby version declarations to the latest patch in the current minor
+mise run ruby-evergreen-patch
+
+# Or update mise.toml directly when doing a manual version bump
 mise use ruby@3.4.8  # or whatever version you need
 
 # Install the updated Ruby version
@@ -39,15 +44,21 @@ mise ls-remote ruby | tail -20
 mise ls-remote ruby | grep "^3.4"
 ```
 
-### 2. Update Ruby Version in mise.toml
+### 2. Update Ruby Version Declarations
 
-**IMPORTANT**: Always use the `mise` CLI to update the version - never manually edit `mise.toml`:
+For automated patch updates in the current Ruby minor:
+
+```bash
+mise run ruby-evergreen-patch
+```
+
+For manual updates, always use the `mise` CLI to update the version in `mise.toml`, then synchronize the Bundler declarations in `Gemfile` and `Gemfile.next`:
 
 ```bash
 # Update to a specific version
 mise use ruby@3.4.8
 
-# This will automatically update mise.toml
+# Then update the matching ruby directives in Gemfile and Gemfile.next
 ```
 
 ### 3. Check for Other Ruby Version References
@@ -107,9 +118,10 @@ mise run brakeman
 
 ## Important Notes
 
-### Single Source of Truth
+### Source of Truth
 
-- `mise.toml` is the **only** place where the Ruby version should be managed
+- `mise.toml` is the runtime source of truth for Ruby selection
+- `Gemfile` and `Gemfile.next` must stay synchronized with `mise.toml` so Bundler resolves against the same version declaration
 - Do NOT create `.ruby-version` files (they are ignored per `mise.toml` settings)
 - All commands should be prefixed with `mise exec --` to ensure version consistency
 
@@ -120,6 +132,13 @@ Patch version updates (e.g., 3.3.10 → 3.3.11 or 3.4.4 → 3.4.8) typically do 
 1. Run `rg` to find any hardcoded references
 2. Review the search results
 3. Update only if the patch version is explicitly referenced
+
+The `Ruby Evergreen` workflow follows a conservative policy:
+
+1. It only proposes the latest patch release within the current Ruby minor
+2. It updates `mise.toml`, `Gemfile`, and `Gemfile.next` together
+3. It refreshes both lockfiles with `bundle install`
+4. It runs `mise run test-smoke` and `mise run test-next-smoke` before opening a PR
 
 ### Major/Minor Version Updates
 
@@ -165,8 +184,9 @@ If RuboCop shows errors after updating:
 The CI environment uses `mise` to manage Ruby versions, so:
 
 1. CI will automatically use the version specified in `mise.toml`
-2. No need to update separate CI configuration for Ruby versions
-3. CI runs `mise install` as part of the setup process
+2. No separate Dependabot configuration is used for Ruby runtime upgrades
+3. The scheduled `Ruby Evergreen` workflow opens a PR for patch updates instead of mutating `develop`
+4. Minor-version Ruby upgrades should stay manual and approval-gated
 
 ## References
 

--- a/mise.toml
+++ b/mise.toml
@@ -117,3 +117,7 @@ run = "mkdir -p tmp && CI=true RAILS_ENV=test TMPDIR=$PWD/tmp bin/rails test:pre
 [tasks.test-next-smoke]
 description = "Fast Next Rails smoke tests"
 run = "mkdir -p tmp && CI=true RAILS_ENV=test TMPDIR=$PWD/tmp next rails test:prepare --trace && next rails test test/controllers test/models"
+
+[tasks.ruby-evergreen-patch]
+description = "Update Ruby version declarations to the latest patch in the current minor"
+run = "ruby scripts/update_ruby_version.rb --latest-patch --apply"

--- a/scripts/update_ruby_version.rb
+++ b/scripts/update_ruby_version.rb
@@ -1,0 +1,101 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require 'open3'
+require 'rubygems/version'
+
+FILES = {
+  'mise.toml' => [/^ruby = "(\d+\.\d+\.\d+)"$/],
+  'Gemfile' => [/^ruby '(\d+\.\d+\.\d+)'$/],
+  'Gemfile.next' => [/^ruby '(\d+\.\d+\.\d+)'$/],
+}.freeze
+
+options = {
+  apply: false,
+  latest_patch: false,
+  target_version: nil,
+}
+
+OptionParser.new do |opts|
+  opts.banner = 'Usage: ruby scripts/update_ruby_version.rb [options]'
+
+  opts.on('--latest-patch', 'Resolve the latest patch release in the current Ruby minor') do
+    options[:latest_patch] = true
+  end
+
+  opts.on('--version VERSION', 'Update to an explicit Ruby version') do |version|
+    options[:target_version] = version
+  end
+
+  opts.on('--apply', 'Write changes back to the tracked files') do
+    options[:apply] = true
+  end
+end.parse!
+
+unless options[:latest_patch] ^ !options[:target_version].nil?
+  abort('Specify exactly one of --latest-patch or --version VERSION')
+end
+
+def extract_version(path, pattern)
+  File.foreach(path) do |line|
+    match = line.match(pattern)
+    return match[1] if match
+  end
+  raise "No Ruby version found in #{path}"
+end
+
+def resolve_latest_patch(current_version)
+  major_minor = current_version.split('.').first(2).join('.')
+  stdout, status = Open3.capture2('mise', 'ls-remote', 'ruby')
+  raise 'Failed to list remote Ruby versions' unless status.success?
+
+  candidates = stdout.lines
+    .map(&:strip)
+    .grep(/\A#{Regexp.escape(major_minor)}\.\d+\z/)
+    .map { |version| Gem::Version.new(version) }
+
+  raise "No remote Ruby versions found for #{major_minor}" if candidates.empty?
+
+  candidates.max.to_s
+end
+
+def apply_version_updates(current_version, target_version, apply:)
+  # rubocop:disable Metrics/BlockLength
+  FILES.each do |path, patterns|
+    original = File.read(path)
+    updated = patterns.reduce(original) do |content, pattern|
+      content.gsub(pattern) { |match| match.sub(current_version, target_version) }
+    end
+
+    raise "Expected to update #{path}, but no matching version string changed" if original == updated
+
+    if apply
+      File.write(path, updated)
+      puts "Updated #{path}"
+    else
+      puts "Would update #{path}"
+    end
+  end
+  # rubocop:enable Metrics/BlockLength
+end
+
+current_version = extract_version('mise.toml', FILES.fetch('mise.toml').first)
+target_version = options[:target_version] || resolve_latest_patch(current_version)
+
+unless Gem::Version.correct?(target_version)
+  abort("Invalid target Ruby version: #{target_version}")
+end
+
+if Gem::Version.new(target_version).segments.first(2) != Gem::Version.new(current_version).segments.first(2)
+  abort("Refusing to cross Ruby minor versions automatically (#{current_version} -> #{target_version})")
+end
+
+puts "Current Ruby version: #{current_version}"
+puts "Target Ruby version:  #{target_version}"
+
+if current_version == target_version
+  puts 'Ruby version is already current.'
+  exit 0
+end
+
+apply_version_updates(current_version, target_version, apply: options[:apply])

--- a/scripts/update_ruby_version.rb
+++ b/scripts/update_ruby_version.rb
@@ -59,9 +59,14 @@ def resolve_latest_patch(current_version)
   candidates.max.to_s
 end
 
+# rubocop:disable Metrics/MethodLength
 def apply_version_updates(current_version, target_version, apply:)
+  seen_targets = {}
+
   # rubocop:disable Metrics/BlockLength
   FILES.each do |path, patterns|
+    resolved_path = File.realpath(path)
+    next if seen_targets[resolved_path]
     original = File.read(path)
     updated = patterns.reduce(original) do |content, pattern|
       content.gsub(pattern) { |match| match.sub(current_version, target_version) }
@@ -75,9 +80,11 @@ def apply_version_updates(current_version, target_version, apply:)
     else
       puts "Would update #{path}"
     end
+    seen_targets[resolved_path] = true
   end
   # rubocop:enable Metrics/BlockLength
 end
+# rubocop:enable Metrics/MethodLength
 
 current_version = extract_version('mise.toml', FILES.fetch('mise.toml').first)
 target_version = options[:target_version] || resolve_latest_patch(current_version)

--- a/scripts/validate-dependabot-v2.rb
+++ b/scripts/validate-dependabot-v2.rb
@@ -14,6 +14,7 @@ class DependabotValidator
     @schema = nil
   end
   
+  # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Naming/PredicateMethod
   def validate
     puts '🔍 Validating Dependabot configuration...'
     
@@ -51,6 +52,7 @@ class DependabotValidator
     end
     
     # Validate each update section
+    # rubocop:disable Metrics/BlockLength
     config['updates'].each_with_index do |update, index|
       puts "  📋 Validating update section #{index + 1}..."
       
@@ -91,9 +93,12 @@ class DependabotValidator
           end
       end
     end
+    # rubocop:enable Metrics/BlockLength
     
     # Check for duplicate ecosystems
-    ecosystems = config['updates'].pluck('package-ecosystem')
+    # rubocop:disable Rails/Pluck
+    ecosystems = config['updates'].map { |update| update['package-ecosystem'] }
+    # rubocop:enable Rails/Pluck
     duplicates = ecosystems.group_by(&:itself).select { |_k, v| v.size > 1 }.keys
     
     if duplicates.any?
@@ -115,6 +120,7 @@ class DependabotValidator
     
     true
   end
+  # rubocop:enable Metrics/AbcSize, Metrics/CyclomaticComplexity, Metrics/MethodLength, Metrics/PerceivedComplexity, Naming/PredicateMethod
   
   def fetch_schema
     puts '📥 Fetching official Dependabot schema...'


### PR DESCRIPTION
## Summary
- harden the Dependabot-driven `Gemfile.next.lock` refresh workflow so it only runs on Dependabot branches and validates before pushing
- add a separate scheduled Ruby evergreen workflow plus a helper script/task to keep `mise.toml` and Bundler Ruby declarations synchronized
- document that Dependabot owns stable gem updates while Ruby patch bumps are proposed by the evergreen workflow
- fix the local Dependabot config validator so this config surface can be validated in hooks and CI

## Governance Flags
- Non-trivial CI/process hardening tied to #2238
- No production runtime behavior change intended; this PR changes upgrade automation and documentation only

## Validation
- `ruby scripts/validate-dependabot-v2.rb`
- YAML parse for `.github/workflows/dependabot.next.yml` and `.github/workflows/ruby-evergreen.yml`
- `mise run test-smoke`
- pre-push hook suite, including RuboCop, Rails tests, and system tests

## Notes
- `mise run test-next-smoke` currently completes with `0 runs` in this repo, so the new workflow keeps that existing smoke task but does not claim broader next-lane coverage than the repo currently provides.
- Related issue: #2238
