### PR TITLE
Docs: add evergreen follow-up OpenSpec changes

### DIFF
--- a/openspec/changes/define-evergreen-upgrade-promotion-path/.openspec.yaml
+++ b/openspec/changes/define-evergreen-upgrade-promotion-path/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/define-evergreen-upgrade-promotion-path/design.md
+++ b/openspec/changes/define-evergreen-upgrade-promotion-path/design.md
@@ -1,0 +1,51 @@
+## Context
+
+The evergreen workflows can detect or prepare upgrade opportunities, but the repo still lacks a formal process for deciding when those opportunities become normal PRs and merge candidates. Without that process, automation can stop at validation and leave ownership unclear, especially across different upgrade classes such as Ruby patch bumps, Ruby minor jumps, stable Rails updates, and prerelease next-lane work.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define distinct promotion flows for the main Ruby and Rails upgrade categories.
+- Clarify the evidence, approvals, and tests required before each upgrade type is proposed or merged.
+- Assign clear ownership boundaries between automation, reviewers, and maintainers.
+- Preserve the repo's conservative production posture while still making automation useful.
+
+**Non-Goals:**
+- Implementing new workflow logic in this design alone.
+- Auto-merging Ruby minor or Rails prerelease upgrades.
+- Changing branch protection or CI policy outside the evergreen promotion scope.
+
+## Decisions
+
+### Model promotion by upgrade class
+Promotion rules will be defined separately for Ruby patch, Ruby minor, stable Rails, and prerelease Rails next-lane updates. Each class has different compatibility risk and should not share one generic merge rule.
+
+Alternative considered: one common promotion path for all upgrades. Rejected because it would either overconstrain patch updates or underconstrain higher-risk upgrades.
+
+### Require evidence before ownership handoff
+Automation output must be accompanied by explicit evidence, such as successful smoke runs, workflow results, or documented compatibility notes, before a human owner is asked to review or merge.
+
+Alternative considered: allow maintainers to infer readiness from bot PRs alone. Rejected because the post-release validation already showed that workflow existence and actual execution can diverge.
+
+### Keep prerelease Rails work validation-only by default
+The next-lane Rails track will remain validation-oriented until a maintainer explicitly chooses to promote it toward production adoption.
+
+Alternative considered: auto-promote next-lane prerelease compatibility changes once CI is green. Rejected because prerelease adoption is a policy decision, not just a CI result.
+
+## Risks / Trade-offs
+
+- [The process becomes too heavy for low-risk patch bumps] -> Mitigation: keep Ruby patch and stable Rails patch flows lightweight, with bounded smoke-test requirements.
+- [Owners may assume automation has already made the merge decision] -> Mitigation: require explicit ownership and approval handoff in the documented path.
+- [Promotion paths drift from actual workflow behavior] -> Mitigation: require the path to reference the real evergreen jobs and verification outputs.
+
+## Migration Plan
+
+1. Define promotion requirements and tasks in OpenSpec.
+2. Align GitHub issues and docs with the promotion scenarios.
+3. Implement any needed workflow or documentation changes in a later follow-up PR.
+4. Use the resulting process as the gate for future evergreen-detected upgrades.
+
+## Open Questions
+
+- Which maintainer role owns Ruby minor upgrade decisions?
+- Should stable Rails minor updates require broader review than stable patch updates in this repo?

--- a/openspec/changes/define-evergreen-upgrade-promotion-path/proposal.md
+++ b/openspec/changes/define-evergreen-upgrade-promotion-path/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+The repo can now detect some upgrade opportunities, but it still lacks a defined path for turning detected Ruby and Rails upgrades into reviewed, mergeable changes. This change is needed now so evergreen automation does not stop at detection or validation without a clear ownership, approval, and merge process.
+
+## What Changes
+
+- Define promotion flows for Ruby patch bumps, Ruby minor bumps, stable Rails updates, and prerelease Rails next-lane upgrades.
+- Specify the approval gates, test gates, and ownership expectations for each promotion scenario.
+- Document the evidence required before an evergreen-detected upgrade can move from automation output to a normal PR and merge decision.
+- Clarify when upgrades remain validation-only and when they become candidates for production adoption.
+
+## Capabilities
+
+### New Capabilities
+- `evergreen-upgrade-promotion`: Defines how Ruby and Rails upgrades move from evergreen detection into proposed, reviewed, and merged changes.
+
+### Modified Capabilities
+
+## Impact
+
+- GitHub Actions evergreen workflows
+- Dependabot and automation PR process
+- upgrade governance and approval flow
+- release-process documentation
+- issue ownership and merge criteria

--- a/openspec/changes/define-evergreen-upgrade-promotion-path/specs/evergreen-upgrade-promotion/spec.md
+++ b/openspec/changes/define-evergreen-upgrade-promotion-path/specs/evergreen-upgrade-promotion/spec.md
@@ -1,0 +1,37 @@
+## ADDED Requirements
+
+### Requirement: Promotion path SHALL classify upgrade types
+The repo SHALL define separate promotion paths for Ruby patch bumps, Ruby minor bumps, stable Rails updates, and prerelease Rails next-lane upgrades.
+
+#### Scenario: Routing a detected upgrade
+- **WHEN** evergreen automation detects or validates an upgrade opportunity
+- **THEN** the repo classifies the opportunity into one of the defined upgrade types before deciding the next action
+
+### Requirement: Promotion path SHALL require evidence before proposal
+The repo SHALL define the minimum verification evidence required before automation output becomes a normal PR or merge candidate.
+
+#### Scenario: Ruby patch bump candidate
+- **WHEN** automation proposes a Ruby patch bump within the current minor line
+- **THEN** the promotion path requires synchronized runtime declarations and passing smoke verification before the PR is treated as reviewable
+
+#### Scenario: Stable Rails update candidate
+- **WHEN** automation or Dependabot proposes a stable Rails update
+- **THEN** the promotion path requires CI evidence appropriate to the affected Rails scope before merge consideration
+
+### Requirement: Higher-risk upgrades SHALL require explicit approval
+The repo SHALL require explicit human approval for higher-risk upgrade classes before they move from validation into mergeable work.
+
+#### Scenario: Ruby minor upgrade candidate
+- **WHEN** the detected upgrade changes the Ruby minor line
+- **THEN** the promotion path requires explicit approval and compatibility review before the repo opens or advances a merge candidate
+
+#### Scenario: Prerelease Rails next-lane result
+- **WHEN** the next-lane workflow validates a prerelease Rails target
+- **THEN** the result remains validation-only unless a maintainer explicitly promotes it into an adoption plan
+
+### Requirement: Promotion path SHALL define ownership handoff
+The repo SHALL define who closes the loop when automation detects an upgrade but cannot safely merge it on its own.
+
+#### Scenario: Automation stops at validation
+- **WHEN** a workflow succeeds in detection or validation but no merge-safe action exists
+- **THEN** the promotion path identifies the maintainer action required to review, propose, or defer the upgrade

--- a/openspec/changes/define-evergreen-upgrade-promotion-path/tasks.md
+++ b/openspec/changes/define-evergreen-upgrade-promotion-path/tasks.md
@@ -1,0 +1,14 @@
+## 1. Upgrade Classification
+
+- [ ] 1.1 Define the upgrade classes covered by the promotion path: Ruby patch, Ruby minor, stable Rails, and prerelease Rails next lane.
+- [ ] 1.2 Map the current evergreen workflows and Dependabot flows to those upgrade classes.
+
+## 2. Promotion Gates
+
+- [ ] 2.1 Define the verification evidence required before each upgrade class becomes a reviewable PR.
+- [ ] 2.2 Define the approval and ownership rules for higher-risk upgrade classes.
+
+## 3. Adoption Process
+
+- [ ] 3.1 Document how validated upgrades move from automation output to proposed work, review, and merge.
+- [ ] 3.2 Document who closes the loop when automation detects an upgrade but cannot safely merge it.

--- a/openspec/changes/review-evergreen-version-baseline/.openspec.yaml
+++ b/openspec/changes/review-evergreen-version-baseline/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-14

--- a/openspec/changes/review-evergreen-version-baseline/design.md
+++ b/openspec/changes/review-evergreen-version-baseline/design.md
@@ -1,0 +1,58 @@
+## Context
+
+The evergreen hardening work is merged, but post-release validation showed that workflow registration alone is not enough to prove the path works on GitHub. The repo now needs a lightweight, repeatable baseline review that compares declared Ruby and Rails versions with upstream releases and confirms that automation, manifests, and documentation still point at the intended upgrade tracks.
+
+The current repo state already provides concrete review inputs:
+
+- `mise.toml` and the Gemfiles declare Ruby `3.3.10`
+- the Rails next lane currently targets `>= 8.1.0.beta1, < 8.2`
+- upstream has Ruby `3.3.11` available in the same minor line
+- upstream has Rails `8.1.3` as the latest stable release
+
+## Goals / Non-Goals
+
+**Goals:**
+- Define a standard review cycle for Ruby and Rails baselines.
+- Enumerate the repo surfaces that must remain consistent during the review.
+- Separate baseline confirmation from actual upgrade promotion or merge decisions.
+- Make the review output actionable for future evergreen PRs and issue triage.
+
+**Non-Goals:**
+- Automatically changing production versions as part of the review.
+- Replacing `next_rails` or redesigning the evergreen workflows in this change.
+- Deciding the final adoption timing for Ruby minor upgrades or future Rails prereleases.
+
+## Decisions
+
+### Review both declared versions and automation targets
+The baseline review will compare both source-of-truth declarations and automation behavior. This is necessary because a repo can declare one version while the evergreen jobs or docs imply a different target.
+
+Alternative considered: only reviewing `mise.toml` and `Gemfile`. Rejected because it would miss drift in workflow config and upgrade documentation.
+
+### Split stable and prerelease tracks
+The review will evaluate stable Ruby/Rails release lines separately from the prerelease Rails next lane. This preserves the repo's current dual-boot strategy and avoids conflating production adoption with compatibility monitoring.
+
+Alternative considered: one combined upgrade recommendation. Rejected because stable adoption and prerelease validation have different risk profiles and owners.
+
+### Treat review output as evidence, not an implicit approval
+The change will define required evidence and decision points, but it will not auto-authorize upgrades. This keeps the review useful even when the best next step is "stay where we are."
+
+Alternative considered: using the review to directly trigger upgrade PRs. Rejected because that belongs in the promotion-path change.
+
+## Risks / Trade-offs
+
+- [Review becomes stale quickly] -> Mitigation: define a repeatable cadence and explicit upstream comparison inputs.
+- [Docs and automation drift independently] -> Mitigation: require the review to inspect manifests, workflows, and docs together.
+- [Baseline review gets mistaken for an upgrade commitment] -> Mitigation: explicitly separate review outcomes from promotion decisions.
+
+## Migration Plan
+
+1. Add baseline-review requirements and tasks to OpenSpec.
+2. Use the change to drive the corresponding GitHub issue scope.
+3. Implement the documented review process in repo docs and evergreen maintenance checklists.
+4. Feed the review output into future upgrade PRs or promotion decisions as separate follow-up work.
+
+## Open Questions
+
+- What review cadence is appropriate for this repo: scheduled monthly, release-driven, or issue-driven?
+- Should the baseline review record upstream release URLs directly in repo docs or only in issue comments?

--- a/openspec/changes/review-evergreen-version-baseline/proposal.md
+++ b/openspec/changes/review-evergreen-version-baseline/proposal.md
@@ -1,0 +1,26 @@
+## Why
+
+The evergreen workflows are now in place, but the repo still needs a repeatable way to confirm that its Ruby and Rails targets remain current and aligned with project policy. A dedicated baseline-review change is needed now because the post-release check already showed runtime gaps in the automation, and the repo's declared versions are behind the latest upstream patch and stable releases.
+
+## What Changes
+
+- Define a repeatable review process for comparing repo-declared Ruby and Rails versions against upstream releases.
+- Specify the evidence required to confirm that the evergreen workflows are targeting the intended Ruby patch line and Rails upgrade lane.
+- Document how version-baseline reviews should classify patch, minor, and prerelease opportunities without forcing immediate production adoption.
+- Capture the repo surfaces that must stay aligned during the review, including `mise.toml`, `Gemfile`, `Gemfile.next`, workflow configuration, and upgrade docs.
+
+## Capabilities
+
+### New Capabilities
+- `evergreen-version-baseline-review`: Reviews the repo's Ruby and Rails baselines against upstream releases and validates that evergreen automation still targets the right upgrade paths.
+
+### Modified Capabilities
+
+## Impact
+
+- `mise.toml`
+- `Gemfile`
+- `Gemfile.next`
+- GitHub Actions evergreen workflows
+- upgrade and runtime management documentation
+- issue triage and release-process review

--- a/openspec/changes/review-evergreen-version-baseline/specs/evergreen-version-baseline-review/spec.md
+++ b/openspec/changes/review-evergreen-version-baseline/specs/evergreen-version-baseline-review/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: Review declared Ruby and Rails baselines
+The repo SHALL provide a repeatable review process that compares declared Ruby and Rails baselines against current upstream releases and records whether the repo is behind, aligned, or intentionally pinned.
+
+#### Scenario: Compare current declarations with upstream releases
+- **WHEN** a maintainer performs an evergreen baseline review
+- **THEN** the review records the repo-declared Ruby version, the repo-declared Rails stable or prerelease target, and the latest relevant upstream Ruby and Rails releases
+
+#### Scenario: Preserve intentional pinning decisions
+- **WHEN** the repo remains on an older Ruby patch, Ruby minor, or Rails target by policy
+- **THEN** the review records that the difference is intentional and names the policy or compatibility reason
+
+### Requirement: Validate evergreen targeting surfaces together
+The repo SHALL review manifests, automation configuration, and upgrade documentation together so evergreen targeting drift is detected in one pass.
+
+#### Scenario: Cross-check all targeting surfaces
+- **WHEN** a baseline review is completed
+- **THEN** it verifies `mise.toml`, `Gemfile`, `Gemfile.next`, evergreen workflows, and upgrade documentation for consistency with the intended Ruby and Rails upgrade tracks
+
+### Requirement: Separate baseline review from upgrade promotion
+The repo SHALL treat baseline review output as evidence for future upgrade decisions rather than as implicit approval to adopt a new Ruby or Rails version.
+
+#### Scenario: Review finds a newer release
+- **WHEN** the review identifies a newer Ruby patch, Ruby minor, or Rails release
+- **THEN** the output classifies the opportunity without requiring an immediate production version change

--- a/openspec/changes/review-evergreen-version-baseline/tasks.md
+++ b/openspec/changes/review-evergreen-version-baseline/tasks.md
@@ -1,0 +1,14 @@
+## 1. Review Inputs
+
+- [ ] 1.1 Inventory the repo files and workflow surfaces that declare or imply Ruby and Rails targets.
+- [ ] 1.2 Document the upstream Ruby and Rails release sources used for baseline comparison.
+
+## 2. Review Process
+
+- [ ] 2.1 Define the repeatable baseline-review procedure for stable Ruby, stable Rails, and the Rails prerelease lane.
+- [ ] 2.2 Document how the review records intentional version lag versus actionable upgrade opportunities.
+
+## 3. Repo Alignment
+
+- [ ] 3.1 Update repo docs or maintenance guidance to reflect the new baseline-review process.
+- [ ] 3.2 Link the review output to evergreen issue triage so future version checks produce actionable follow-up work.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,20 @@
+schema: spec-driven
+
+# Project context (optional)
+# This is shown to AI when creating artifacts.
+# Add your tech stack, conventions, style guides, domain knowledge, etc.
+# Example:
+#   context: |
+#     Tech stack: TypeScript, React, Node.js
+#     We use conventional commits
+#     Domain: e-commerce platform
+
+# Per-artifact rules (optional)
+# Add custom rules for specific artifacts.
+# Example:
+#   rules:
+#     proposal:
+#       - Keep proposals under 500 words
+#       - Always include a "Non-goals" section
+#     tasks:
+#       - Break tasks into chunks of max 2 hours


### PR DESCRIPTION
## Summary
- initialize OpenSpec in the repo with the base `openspec/config.yaml`
- add an OpenSpec change for reviewing the repo's evergreen Ruby/Rails baselines
- add an OpenSpec change for defining the promotion path from evergreen detection to adoption

## Context
- post-release validation confirmed PR #2245 merged, but issue #2238 is still open because both new workflows are still hitting `startup_failure`
- issue #2268 tracks the version-baseline review follow-up
- issue #2269 tracks the upgrade-promotion-path follow-up

## Verification
- `openspec validate review-evergreen-version-baseline`
- `openspec validate define-evergreen-upgrade-promotion-path`
- `mise exec -- git push -u origin chore/evergreen-followup-specs` (passed pre-push hooks, including Rails and system tests)

Refs #2268
Refs #2269
