### PR TITLE
CI: fix workflow startup failures for evergreen automation

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@v2.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -21,9 +21,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Auto-approve PR
-        uses: hmarr/auto-approve-action@v4
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review --approve "${{ github.event.pull_request.number }}" \
+            --body "Auto-approved by CI for Dependabot PR. Auto-merge will occur after required checks pass."
 
       - name: Enable auto-merge for safe updates
         # Auto-merge patch updates, minor updates for dev deps, and all development dependencies

--- a/.github/workflows/dependabot.next.yml
+++ b/.github/workflows/dependabot.next.yml
@@ -23,13 +23,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup mise environment
-        uses: jdx/mise-action@v4
-
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq libyaml-dev libpq-dev
+          sudo apt-get install -y -qq jq libyaml-dev libpq-dev
+
+      - name: Setup Environment via mise
+        env:
+          SETUP_SKIP_NODE: "true"
+        run: |
+          bash bin/setup-environment.sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Refresh Gemfile.next.lock
         env:

--- a/.github/workflows/ruby-evergreen.yml
+++ b/.github/workflows/ruby-evergreen.yml
@@ -22,13 +22,17 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup mise environment
-        uses: jdx/mise-action@v4
-
       - name: Install system dependencies
         run: |
           sudo apt-get update -qq
-          sudo apt-get install -y -qq libyaml-dev libpq-dev
+          sudo apt-get install -y -qq jq libyaml-dev libpq-dev
+
+      - name: Setup Environment via mise
+        env:
+          SETUP_SKIP_NODE: "true"
+        run: |
+          bash bin/setup-environment.sh
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Update Ruby version files to latest patch
         id: update_ruby
@@ -60,25 +64,41 @@ jobs:
         if: steps.update_ruby.outputs.changed == 'true'
         run: mise run test-next-smoke
 
-      - name: Create pull request
+      - name: Commit branch and open pull request
         if: steps.update_ruby.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          commit-message: "Build(ruby): bump Ruby to ${{ steps.update_ruby.outputs.version }}"
-          title: "Build(ruby): bump Ruby to ${{ steps.update_ruby.outputs.version }}"
-          body: |
-            ## Summary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.update_ruby.outputs.version }}"
+          BRANCH="chore/ruby-evergreen-${VERSION}"
+          TITLE="Build(ruby): bump Ruby to ${VERSION}"
 
-            - bumps Ruby to the latest patch release in the current minor line
-            - updates `mise.toml`, `Gemfile`, `Gemfile.next`, and refreshed lockfiles
-            - runs stable and next-lane smoke tests before opening the PR
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
-            Related to #2238.
-          branch: chore/ruby-evergreen-${{ steps.update_ruby.outputs.version }}
-          delete-branch: true
-          add-paths: |
-            Gemfile
-            Gemfile.lock
-            Gemfile.next
-            Gemfile.next.lock
-            mise.toml
+          git checkout -B "$BRANCH"
+          git add Gemfile Gemfile.lock Gemfile.next Gemfile.next.lock mise.toml
+          git commit -m "$TITLE"
+          git push --force-with-lease origin "$BRANCH"
+
+          EXISTING_PR="$(gh pr list --head "$BRANCH" --base develop --json number --jq '.[0].number // ""')"
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists for $BRANCH"
+            exit 0
+          fi
+
+          cat > /tmp/ruby-evergreen-pr.md <<EOF
+          ## Summary
+
+          - bumps Ruby to the latest patch release in the current minor line
+          - updates \`mise.toml\`, \`Gemfile\`, \`Gemfile.next\`, and refreshed lockfiles
+          - runs stable and next-lane smoke tests before opening the PR
+
+          Related to #2238.
+          EOF
+
+          gh pr create \
+            --base develop \
+            --head "$BRANCH" \
+            --title "$TITLE" \
+            --body-file /tmp/ruby-evergreen-pr.md


### PR DESCRIPTION
## Summary
- replace blocked marketplace actions in the evergreen workflows with repo-compatible shell setup and `gh` steps
- switch Ruby evergreen PR creation from `peter-evans/create-pull-request` to explicit `git` + `gh pr create`
- replace Dependabot auto-approval with the same `gh pr review --approve` pattern already used elsewhere in the repo

## Why
The repo is configured with selected Actions allowlists. The failing workflows were still referencing non-allowlisted third-party marketplace actions, which caused `startup_failure` before any jobs were created.

## Validation
- local YAML parse for all edited workflows
- local blocked-action scan for `jdx/mise-action`, `peter-evans/create-pull-request`, and `hmarr/auto-approve-action`
- pre-push hook suite passed, including YAML lint and Rails tests

Related to #2238.
