### PR TITLE
Docs: add production acceptance and rollback gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,48 @@
+## Summary
+
+<!-- Describe the change in 2-5 bullets. -->
+
+## Linked Issue
+
+<!-- Required for non-trivial work. Example: Closes #1234 -->
+
+## Acceptance Criteria
+
+<!-- Copy the relevant A/C or link to the issue section that defines them. -->
+
+## Verification
+
+- [ ] Local verification completed
+- [ ] GitHub/preview/production-adjacent verification completed where applicable
+- [ ] Unverified items are explicitly listed below
+
+### Verified
+
+<!-- Commands run, workflows exercised, screenshots checked, URLs, logs, etc. -->
+
+### Not Verified
+
+<!-- Be explicit. Write `None` if everything relevant is covered. -->
+
+## Rollback / Feature Flag
+
+- [ ] This change is feature-flagged, or
+- [ ] This change is revert-ready
+
+### Rollout Posture
+
+<!-- Explain the feature flag path, or explain why this is safe to ship unflagged. -->
+
+### Rollback Path
+
+<!-- Fastest safe revert path: revert PR, rollback commit, disable workflow, etc. -->
+
+## User Acceptance
+
+- [ ] User accepted the change
+- [ ] User explicitly approved merge without waiting for acceptance
+- [ ] Not yet accepted; treat as `validated-not-accepted`
+
+### Acceptance Evidence
+
+<!-- Link the approving comment, issue note, test artifact, or decision record. -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,10 +25,15 @@ This repository is self-contained. Do not assume a global AI setup exists.
   - secrets, auth, credentials, or permission changes
   - bypassing existing tests, hooks, or validation
   - scope expansion beyond the stated task or linked issue
+- Treat these as explicit completion gates for production-adjacent work:
+  - technical verification is complete
+  - rollback or feature-flag posture is documented
+  - user acceptance is explicitly recorded, or the user explicitly approved proceeding without it
 - Never:
   - commit or print secrets
   - use `--no-verify`
   - claim verification ran when it did not
+  - present production-adjacent work as complete when it is only technically validated and not yet user accepted
 
 Use these baseline orientation commands before non-trivial work:
 
@@ -40,6 +45,38 @@ mise exec -- bin/rails db:version
 ```
 
 When governance is triggered in a review, planning note, or automation artifact, include a `## Governance Flags` section listing the rule, trigger reason, and resolution or required approval.
+
+## 0.1 Production Acceptance Gate
+
+For any `production-adjacent` change, agents MUST treat the work as incomplete until all of the following are true:
+
+- the linked issue has explicit acceptance criteria
+- verification evidence is recorded
+- the rollback path or feature-flag posture is recorded
+- the user has accepted the outcome, or has explicitly authorized merge/closure without waiting for acceptance
+
+`Production-adjacent` includes:
+
+- deploy or release automation
+- CI/CD workflows that can mutate branches, PRs, environments, or scheduled automation behavior
+- feature-flag changes, runtime configuration, or production environment logic
+- changes whose success depends on live behavior after merge
+
+When production-adjacent work is technically validated but not yet accepted, agents MUST describe it as:
+
+- `validated-not-accepted`
+
+Agents MUST NOT merge, close the linked issue, or describe the work as complete unless either:
+
+- user acceptance is explicitly recorded, or
+- the user explicitly directs the agent to proceed without acceptance
+
+For production-adjacent work, the final summary before merge or close MUST answer:
+
+- what was verified
+- what was not verified
+- what the rollback or flagging path is
+- who accepted the work, or whether the user explicitly overrode that requirement
 
 ---
 
@@ -116,6 +153,16 @@ When governance is triggered in a review, planning note, or automation artifact,
     - Adding missing tests for existing code
   - **If no issue exists**: Create one first before starting implementation
   - **If A/C unclear**: Ask user to define them before proceeding
+
+- **Production-adjacent work requires acceptance and rollback tracking**
+
+  - For production-adjacent work, agents MUST capture in the issue, PR, or final handoff:
+    - verification evidence
+    - explicit unverified items
+    - rollback path or feature-flag posture
+    - user acceptance status
+  - If user acceptance has not happened yet, agents MUST call the work `validated-not-accepted`.
+  - Agents MUST NOT merge or close production-adjacent work without user acceptance unless the user explicitly authorizes that exception in the current session.
 
 - **Use the mise toolchain**
 

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -149,6 +149,75 @@ If headless browser verification is not configured or fails to run, the agent mu
 
 This is a **prompt-level/dev workflow** policy only. It does not require any changes to the Rails application itself.
 
+## Production Acceptance and Rollback Gate
+
+Technical validation is necessary but not sufficient for production-adjacent work.
+
+### Work classification
+
+Treat the following as `production-adjacent`:
+
+- deploy, release, CI, or workflow automation that can affect production behavior
+- runtime configuration and environment behavior
+- scheduled jobs or bots that can mutate branches, pull requests, or release flow
+- changes whose real success depends on live behavior after merge
+
+### Required state transitions
+
+Production-adjacent work must move through these states explicitly:
+
+1. `implemented`
+2. `validated`
+3. `validated-not-accepted`
+4. `accepted`
+
+Agents must not collapse `validated` into `accepted`.
+
+### Required evidence before merge
+
+For any production-adjacent PR, record all of the following in the PR body, issue, or closeout note:
+
+- **Verification**
+  - what was tested locally
+  - what was verified on GitHub, preview, or production-adjacent infrastructure
+  - what remains unverified
+- **Rollback / Flagging**
+  - feature flag path, if one exists
+  - otherwise, the revert-ready path
+  - the fastest safe rollback action available
+- **User Acceptance**
+  - who accepted the work, or
+  - the explicit instruction from the user to merge without waiting for acceptance
+
+### Merge and close rules
+
+Agents MUST NOT merge or close production-adjacent work if any of these are missing:
+
+- a linked issue with acceptance criteria
+- recorded verification evidence
+- recorded rollback or flag posture
+- explicit user acceptance, unless the user explicitly overrides that gate
+
+If the work is technically validated but not yet user accepted, the agent must describe it as `validated-not-accepted` and leave the issue or PR open unless the user says otherwise.
+
+### Preferred rollout posture
+
+- Prefer feature flags for user-facing production changes when a flag already exists or can be added cheaply.
+- If feature flags are not practical, require a documented revert path before merge.
+- For workflow and automation changes, the revert path can be:
+  - a revert PR reference
+  - a single-commit rollback plan
+  - a clear “disable this workflow or restore previous workflow version” note
+
+### Required final handoff summary
+
+Before merge/close, the agent must answer these four questions in plain language:
+
+- What was verified?
+- What was not verified?
+- What is the rollback or flagging path?
+- Who accepted the work?
+
 ### ⚠️ Known CSS Conflicts & Gotchas
 
 #### Materialize CSS Override Issue


### PR DESCRIPTION
## Summary
- add a production-adjacent acceptance gate to the repo agent contract
- add deeper guidance for `validated-not-accepted`, rollback, and acceptance evidence in `docs/AGENTS.md`
- add a PR template section for acceptance criteria, verification, rollback/flagging, and user acceptance

## Why
Recent workflow hardening work showed a process gap: technical verification happened, but the repo did not explicitly require user acceptance or a rollback/feature-flag posture before treating production-adjacent work as done.

## Verification
- pre-commit hooks passed
- pre-push hooks passed
- Rails tests passed in pre-push
- system tests passed in pre-push

## Notes
- I had to clear disposable worktree SQLite files once so the local pre-push system-test setup could recreate its DB cleanly. The tracked repo changes are docs/template only.

Closes #2315
