### PR TITLE
Hook: reset disposable system test sqlite db

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -85,26 +85,30 @@ pre-push:
       run: |
         REPO_ROOT="$(git rev-parse --show-toplevel)"
         MISE_RUN=(mise --cd "$REPO_ROOT" run)
+        SYSTEM_TEST_DB='db/test-system.sqlite3'
         if [ -f .env ]; then . ./.env; fi
         if ./scripts/should-run-system-tests.sh; then
           echo "⏭️  Skipping system tests (safe changes only)"
           exit 0
         fi
 
+        echo "🧹 Resetting disposable system test SQLite files..."
+        rm -f -- "$SYSTEM_TEST_DB" "$SYSTEM_TEST_DB"-* "$SYSTEM_TEST_DB"_*
+
         echo "🚀 Setting up system test environment..."
-        if ! TEST_DATABASE_NAME='db/test-system.sqlite3' "${MISE_RUN[@]}" setup-test; then
+        if ! TEST_DATABASE_NAME="$SYSTEM_TEST_DB" "${MISE_RUN[@]}" setup-test; then
           echo "❌ Failed to set up system test environment"
           exit 1
         fi
 
         echo "🔧 Preparing system test database..."
-        if ! TEST_DATABASE_NAME='db/test-system.sqlite3' "${MISE_RUN[@]}" test-prepare; then
+        if ! TEST_DATABASE_NAME="$SYSTEM_TEST_DB" "${MISE_RUN[@]}" test-prepare; then
           echo "❌ Failed to prepare system test database"
           exit 1
         fi
 
         echo "🧪 Running system tests..."
-        if ! TEST_DATABASE_NAME='db/test-system.sqlite3' "${MISE_RUN[@]}" test-system; then
+        if ! TEST_DATABASE_NAME="$SYSTEM_TEST_DB" "${MISE_RUN[@]}" test-system; then
           echo "❌ System tests failed"
           exit 1
         fi


### PR DESCRIPTION
## Summary
Fix the local-only pre-push failure caused by stale disposable SQLite files in reused worktrees.

## Linked Issue
None. This is a narrow hook fix for the verified `db/test-system.sqlite3` setup failure path.

## Acceptance Criteria
- Reused worktrees do not fail pre-push system-test setup because of stale `db/test-system.sqlite3` state.
- The cleanup is limited to the disposable system-test database used by the pre-push hook.
- Main test and system-test flows still pass.

## Verification
- Created a stale `db/test-system.sqlite3` manually, then verified cleanup + `mise run setup-test` + `mise run test-prepare` succeeded.
- `mise exec -- git diff --check`
- `mise exec -- git push -u origin fix/sqlite-worktree-prepush`
  - pre-push `rails-tests`: passed
  - pre-push `rails-system-tests`: passed

## Rollback / Feature Flag
- Rollout posture: revert-ready docs/hook fix.
- Rollback path: revert this PR; no data migration or production behavior change.

## User Acceptance
- Status: validated-not-accepted
- Evidence: requested repo fix for recurring local stale-SQLite blocker.
