### PR TITLE
chore: add shellcheck IDE path and git security scrubbing guide

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,6 @@
   "debug.javascript.defaultRuntimeExecutable": {
     "pwa-node": "/Users/temp/.local/share/mise/shims/node"
   },
-  "python.defaultInterpreterPath": "/Users/temp/.local/share/mise/installs/python/3.12.9/bin/python"
+  "python.defaultInterpreterPath": "/Users/temp/.local/share/mise/installs/python/3.12.9/bin/python",
+  "shellcheck.executablePath": "/Users/temp/.local/share/mise/shims/shellcheck"
 }

--- a/GIT_SECURITY_SCRUBBING.md
+++ b/GIT_SECURITY_SCRUBBING.md
@@ -1,0 +1,74 @@
+# Git Security Scrubbing Guide
+
+This document provides a standard operating procedure for removing sensitive information (API keys, credential keys, etc.) from a Git repository's history. 
+
+> [!CAUTION]
+> **Git never forgets.** Even if you delete a file in a new commit, it remains in the history. To truly secure a public repository, you must rewrite the history and purge GitHub's internal caches.
+
+## Prerequisites
+- Install `git-filter-repo`: `brew install git-filter-repo`
+- **Verified Backups**: Ensure you have the physical `*.key` files and `*.yml.enc` files stored in a secure location outside the repository (e.g., a password manager).
+
+---
+
+## Step 1: Identification & Verification
+1. **Find the Secrets**: Use `git grep` to find literal secret strings across all commits.
+   ```bash
+   git grep "YOUR_SECRET_STRING" $(git rev-list --all)
+   ```
+2. **Verify Decryption**: Ensure your current key works for your credentials.
+   ```bash
+   RAILS_MASTER_KEY=$(cat config/credentials/production.key) bundle exec rails credentials:show --environment production
+   ```
+
+## Step 2: The "Surgical" Scrub
+Use `git-filter-repo` to permanently remove files and replace strings.
+
+1. **Create a secret list**: Create a `secrets.txt` file with one secret per line (ensure no trailing newlines/spaces).
+2. **Purge Files and Replace Text**:
+   ```bash
+   # Remove sensitive files from ALL commits
+   git filter-repo --force --path .env.development \
+                   --path .env.test.local \
+                   --path config/credentials/development.key \
+                   --path config/credentials/test.key \
+                   --path config/credentials/production.key \
+                   --invert-paths
+
+   # Replace literal strings with a placeholder
+   git filter-repo --force --replace-text secrets.txt
+   ```
+
+## Step 3: Synchronizing Branches
+Force-update your primary branches to match the clean history.
+```bash
+# Sync master to the clean develop
+git checkout master
+git reset --hard develop
+```
+
+## Step 4: The GitHub "Clean Slate" (Crucial)
+GitHub's internal database caches Pull Request diffs and orphaned commits. **To truly remove secrets from a public repo, you must recreate it.**
+
+1. **Delete the Repo**: Go to **GitHub > Settings > Danger Zone > Delete this repository**.
+2. **Recreate the Repo**: Create a new empty repository with the same name.
+3. **Push Clean History**:
+   ```bash
+   git remote remove origin
+   git remote add origin https://github.com/USER/REPO.git
+   git push -u origin develop
+   git push origin master
+   ```
+
+## Step 5: Post-Scrub Restoration
+1. **Rotate Secrets**: Treat every scrubbed secret as compromised. Generate new keys/passwords as soon as possible.
+2. **GitHub Secrets**: Re-add `RAILS_TEST_KEY`, etc., to **Settings > Secrets and variables > Actions**.
+3. **Branch Protection**: Import the `github_ruleset_production.json` to restore safety rules.
+4. **Cleanup**: Delete the local `secrets.txt` and temporary ruleset files.
+
+---
+
+## How to Prevent Future Leaks
+- **Never commit `.env` files**: Ensure they are in `.gitignore` from day one.
+- **Use Rails Credentials**: Always store secrets in `config/credentials/*.yml.enc`.
+- **Pre-commit Hooks**: Use `Lefthook` or `pre-commit` to scan for secrets before they are ever committed.


### PR DESCRIPTION
## Summary

Two developer-tooling improvements:

1. **`.vscode/settings.json`** — adds `shellcheck.executablePath` pointing to the mise-managed shim so VS Code picks up the correct shellcheck binary from the project toolchain.

2. **`GIT_SECURITY_SCRUBBING.md`** — new developer guide covering the standard operating procedure for removing sensitive information from git history using `git-filter-repo`, including: identification, surgical scrub, branch sync, GitHub clean-slate, post-scrub restoration, and prevention tips.

## Changes
- `.vscode/settings.json`: +1 line (shellcheck path)
- `GIT_SECURITY_SCRUBBING.md`: new file (76 lines)

## Testing
- Pre-push hooks passed locally: 64 Rails tests (221 assertions), 33 system tests (150 assertions), 0 failures
- No runtime code changes — docs and IDE config only
