### PR TITLE
fix: search bar horizontal layout (fixes #1216)

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -52,14 +52,7 @@ body {
 .btn-small {
   background-color: #1c5b82;
 }
-.search-bar {
-  width: 100%;
-  border-radius: 15px;
-  border: 1px #000 solid;
-  padding: 5px 5px 5px 25px;
-  display: inline-block;
-  color: var(--color-text);
-}
+/* .search-bar styles moved to search-bar.css */
 
 .landing-logo {
   margin-top: 100px;


### PR DESCRIPTION
## Summary

Fixes #1216 — Search bar elements were stacking vertically instead of being aligned horizontally.

## Root Cause

`application.css` contained a legacy `.search-bar` rule with `display: inline-block` that overrode the correct `display: flex` from `search-bar.css`. Since Sprockets' `require_self` places inline styles at the bottom of the compiled CSS, the legacy rule took precedence.

## Fix

Removed the 8-line conflicting `.search-bar` block from `application.css`. The proper flex-based layout in `search-bar.css` now applies correctly.

## Before (mobile 375px)

Elements stacked vertically: location icon on top, input below, search button at bottom.

## After (mobile 375px)

All elements in a single horizontal row: `[◎ location] [input field] [🔍 search]`

## Tests

- 76 unit tests: ✅ 0 failures
- 33 system tests: ✅ 0 failures, 150 assertions
