### PR TITLE
fix: trigger test CI on dependabot push events

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -218,7 +218,7 @@ jobs:
     needs: [get-risk-assessment]
     if: |
       always() && !cancelled() && (
-      (github.event_name == 'push' && github.ref == 'refs/heads/develop') ||
+      (github.event_name == 'push' && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/dependabot/'))) ||
       (github.event_name == 'workflow_run' && github.event.workflow_run.head_branch == 'develop') ||
       ((github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch') && 
        (needs.get-risk-assessment.result == 'success' || needs.get-risk-assessment.result == 'skipped')))


### PR DESCRIPTION
## Problem

The `test` job in `main.yml` only ran on push events to `refs/heads/develop`, but the workflow also triggers on pushes to `dependabot/**` branches. This meant the `test` commit status was never created for dependabot PRs, blocking merges that require the `test` required status check.

This has blocked steward from merging dependabot PRs **5+ times** (#2890-#2894), triggering the rule-of-3s threshold.

## Root Cause

The `test` job's `if` condition:
```yaml
github.event_name == 'push' && github.ref == 'refs/heads/develop'
```

When dependabot pushes to `dependabot/bundler/...`, the ref doesn't match `develop`, so the `test` job is skipped and the `createCommitStatus` step never fires.

## Fix

One-line change to the `test` job condition:
```yaml
github.event_name == 'push' && (github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/dependabot/'))
```

System tests are still properly skipped for low-risk dependabot updates via the existing `github.actor != 'dependabot[bot]'` guards.