### PR TITLE
Fix #2901 (Conductor Orchestrated)

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -4,7 +4,7 @@ class Review < ApplicationRecord
   belongs_to :user
   belongs_to :coffeeshop
   scope :order_reviews,
-        ->(user_id) { where('user_id == ?', user_id).order(rating: :desc) }
+        ->(user_id) { where(user_id: user_id).order(rating: :desc) }
 
   # after_create_commit { broadcast_prepend_to 'reviews' }
   # after_update_commit { broadcast_replace_to 'reviews' }


### PR DESCRIPTION
Automated solution for issue #2901

**Status**: Tests failed

Test output (local conductor run):
```

[33mmise[0m [33mWARN[0m  env value contains '$' which will be expanded in a future release. Set `env_shell_expand = true` to opt in or `env_shell_expand = false` to keep current behavior and suppress this warning.
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/lockfile_parser.rb:108:in `warn_for_outdated_bundler_version': You must use Bundler 2 or greater with this lockfile. (Bundler::LockfileError)
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/lockfile_parser.rb:95:in `initialize'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/definition.rb:83:in `new'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/definition.rb:83:in `initialize'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/dsl.rb:234:in `new'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/dsl.rb:234:in `to_definition'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/dsl.rb:13:in `evaluate'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/definition.rb:34:in `build'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler.rb:135:in `definition'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler.rb:101:in `setup'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/setup.rb:20:in `<top (required)>'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `rescue in require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:34:in `require'
	from /Users/temp/workspace/yelp_search_demo/config/boot.rb:3:in `<top (required)>'
	from bin/rails:3:in `require_relative'
	from bin/rails:3:in `<main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/dependency.rb:313:in `to_specs': Could not find 'bundler' (2.7.1) required by your /Users/temp/workspace/yelp_search_demo/Gemfile.lock. (Gem::MissingSpecVersionError)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:2.7.1`
Checked in 'GEM_PATH=/Library/Ruby/Gems/2.6.0:/Users/temp/.gem/ruby/2.6.0:/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0', execute `gem env` for more information
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/dependency.rb:323:in `to_spec'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_gem.rb:65:in `gem'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:42:in `require'
	from /Users/temp/workspace/yelp_search_demo/config/boot.rb:3:in `<top (required)>'
	from bin/rails:3:in `require_relative'
	from bin/rails:3:in `<main>'

```

Agent results:
- **coder**: Completed via Ollama: 1 file(s) changed

## 🤖 Conductor Workflow Trace
- **System**: GitHub Orchestrator (Autonomous Agent System)
- **Workflow**: Triage → Planning → Agent Coordination → Merge & Test → PR Creation
- **Transparency**: This PR was generated through automated agent coordination
- **Documentation**: See [Conductor Architecture](../docs/2026_ARCHITECTURE_PLAN.md#autonomous-workflow)
