### PR TITLE
Fix #1331 (Conductor Orchestrated)

### DIFF
--- a/memory/lefthook_corruption_prevention_guide.md
+++ b/memory/lefthook_corruption_prevention_guide.md
@@ -1,0 +1,26 @@
+# 🛡️ lefthook Corruption Prevention Guide
+
+This memory entry outlines best practices and mandatory steps to prevent configuration corruption within the `lefthook.yml` file. Maintaining the integrity of the hooks is critical for reliable CI/CD pipelines.
+
+## 🚨 What is Corruption?
+Corruption generally refers to the accidental removal, misplacement, or invalidation of key properties (like `pre-command`, `post-command`, or specific `mise` environment fixes) which leads to hooks failing silently or executing incorrectly.
+
+## ✅ Prevention Workflow
+Always follow these steps when modifying `lefthook.yml`:
+
+1. **Backup:** Always commit the current working `lefthook.yml` file with a descriptive message *before* making changes.
+2. **Targeted Edits:** Only modify the specific hook or section required. Never perform large-scale, sweeping edits.
+3. **Validate Syntax:** Run `lefthook lint` immediately after making changes to ensure the YAML structure is valid.
+4. **Test Execution:** Run `lefthook test` to confirm that all existing hooks (especially those related to `mise` environment setup) execute correctly with the new configuration.
+5. **Review:** Submit a Pull Request detailing *why* the change is needed and *what* specific hook is affected.
+
+## 🚫 Properties to Avoid (Known Invalid/Deprecated)
+Never include the following properties, as they are invalid or deprecated in modern lefthook versions:
+- `shell`
+- `verbose`
+- `skip_output`
+- `pre-command` (Use `pre-hook` or structured hooks instead)
+- `post-command` (Use `post-hook` or structured hooks instead)
+- `fixer`
+- Any `workflow-*` commands (Use dedicated CI/CD system configuration)
+- `skip: true` (Null skips are deprecated)


### PR DESCRIPTION
Automated solution for issue #1331

**Status**: Tests failed

Test output (local conductor run):
```

[33mmise[0m [33mWARN[0m  env value contains '$' which will be expanded in a future release. Set `env_shell_expand = true` to opt in or `env_shell_expand = false` to keep current behavior and suppress this warning.
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/lockfile_parser.rb:108:in `warn_for_outdated_bundler_version': You must use Bundler 2 or greater with this lockfile. (Bundler::LockfileError)
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/lockfile_parser.rb:95:in `initialize'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/definition.rb:83:in `new'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/definition.rb:83:in `initialize'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/dsl.rb:234:in `new'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/dsl.rb:234:in `to_definition'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/dsl.rb:13:in `evaluate'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/definition.rb:34:in `build'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler.rb:135:in `definition'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler.rb:101:in `setup'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/bundler/setup.rb:20:in `<top (required)>'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:130:in `rescue in require'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:34:in `require'
	from /Users/temp/workspace/yelp_search_demo/config/boot.rb:3:in `<top (required)>'
	from bin/rails:3:in `require_relative'
	from bin/rails:3:in `<main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/dependency.rb:313:in `to_specs': Could not find 'bundler' (2.7.1) required by your /Users/temp/workspace/yelp_search_demo/Gemfile.lock. (Gem::MissingSpecVersionError)
To update to the latest version installed on your system, run `bundle update --bundler`.
To install the missing version, run `gem install bundler:2.7.1`
Checked in 'GEM_PATH=/Library/Ruby/Gems/2.6.0:/Users/temp/.gem/ruby/2.6.0:/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/gems/2.6.0', execute `gem env` for more information
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/dependency.rb:323:in `to_spec'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_gem.rb:65:in `gem'
	from /System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/rubygems/core_ext/kernel_require.rb:42:in `require'
	from /Users/temp/workspace/yelp_search_demo/config/boot.rb:3:in `<top (required)>'
	from bin/rails:3:in `require_relative'
	from bin/rails:3:in `<main>'

```

Agent results:
- **coder**: Completed via Ollama: 1 file(s) changed

## 🤖 Conductor Workflow Trace
- **System**: GitHub Orchestrator (Autonomous Agent System)
- **Workflow**: Triage → Planning → Agent Coordination → Merge & Test → PR Creation
- **Transparency**: This PR was generated through automated agent coordination
- **Documentation**: See [Conductor Architecture](../docs/2026_ARCHITECTURE_PLAN.md#autonomous-workflow)
