### PR TITLE
fix(ci): ruby-evergreen version capture produced empty string

### DIFF
--- a/.github/workflows/ruby-evergreen.yml
+++ b/.github/workflows/ruby-evergreen.yml
@@ -39,7 +39,12 @@ jobs:
         run: |
           set -euo pipefail
           mise exec -- ruby scripts/update_ruby_version.rb --latest-patch --apply
-          echo "version=$(mise exec -- ruby -e 'puts File.read(\"mise.toml\")[/ruby = \"([^\"]+)\"/, 1]')" >> "$GITHUB_OUTPUT"
+          VERSION="$(mise exec -- ruby -e 'puts File.read("mise.toml")[/ruby = "([^"]+)"/, 1]')"
+          if [ -z "$VERSION" ]; then
+            echo "ERROR: could not extract ruby version from mise.toml" >&2
+            exit 1
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           if git diff --quiet -- mise.toml Gemfile Gemfile.next; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
## Summary
- The version extraction in ruby-evergreen.yml used escaped double-quotes inside a single-quoted shell string; Ruby received the backslashes literally and raised a syntax error, so `steps.update_ruby.outputs.version` was always empty.
- Result: branch `chore/ruby-evergreen-` and title `Build(ruby): bump Ruby to ` (see #2948).
- Fix: plain double-quotes inside the single-quoted Ruby one-liner, plus fail-fast if the extracted version is empty.

## Validation
- Old one-liner reproduced locally: Ruby syntax error, empty output.
- New one-liner extracts `3.3.11` from current mise.toml.
- Workflow YAML parses (`YAML.load_file`).