### PR TITLE
fix(ci): trigger Claude review on PR review @claude mentions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,6 +5,10 @@ on:
     types: [opened, synchronize, reopened]
   issue_comment:
     types: [created]
+  pull_request_review:
+    types: [submitted]
+  pull_request_review_comment:
+    types: [created]
 
 permissions:
   id-token: write  # Required for OIDC token generation
@@ -21,6 +25,10 @@ jobs:
         github.event_name == 'pull_request' ||
         (github.event_name == 'issue_comment' && 
          github.event.issue.pull_request &&
+         contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' &&
+         contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' &&
          contains(github.event.comment.body, '@claude'))
       )
     env:


### PR DESCRIPTION
## Summary
- `@claude` in a PR **review** body fires `pull_request_review`, not `issue_comment` — the workflow only listened to the latter, so review mentions were silently ignored (seen on #2948).
- Adds `pull_request_review` + `pull_request_review_comment` triggers with matching `@claude` guards in the job condition.

## Validation
- YAML parses.
- Full test suite via pre-push hooks: 87 runs, 0 failures.