### PR TITLE
fix: use standard SQL = operator instead of == in Review.order_reviews scope (#2901)

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -4,7 +4,7 @@ class Review < ApplicationRecord
   belongs_to :user
   belongs_to :coffeeshop
   scope :order_reviews,
-        ->(user_id) { where('user_id == ?', user_id).order(rating: :desc) }
+        ->(user_id) { where(user_id:).order(rating: :desc) }
 
   # after_create_commit { broadcast_prepend_to 'reviews' }
   # after_update_commit { broadcast_replace_to 'reviews' }


### PR DESCRIPTION
## Summary

Replaces the non-standard SQL `==` operator with standard Rails hash syntax in the `Review.order_reviews` scope. The `==` operator works in SQLite but fails on PostgreSQL and MySQL.

## Change

`app/models/review.rb:7`

```diff
- ->(user_id) { where('user_id == ?', user_id).order(rating: :desc) }
+ ->(user_id) { where(user_id:).order(rating: :desc) }
```

Also auto-corrected by RuboCop (`Rails/WhereEquals` + `Style/HashSyntax`) to use the Ruby 3.1+ keyword argument shorthand.

## Related

- Closes #2901

## Verification

- [x] RuboCop passes (auto-corrected)
- [x] Rails tests pass (84 runs, 0 failures)