### PR TITLE
fix(ci): stop duplicate CI runs on Dependabot branches

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ on:
   push:
     branches:
       - develop
-      - 'dependabot/**'
   pull_request:
     branches:
       - develop


### PR DESCRIPTION
## Summary
- Dependabot PRs ran the full suite twice (push to `dependabot/**` + `pull_request` to develop). Removes the push-lane duplication; the `pull_request` lane is what satisfies branch protection.
- Evidence it's safe: feature-branch PRs have no push lane and merge normally (#2886, #2971, #2974).

Part of #2981 (P1).

## Validation
- YAML parses.
- Pre-push suite: 87 runs, 0 failures.